### PR TITLE
feat: MVP pipeline + Cloudflare provider with TXT ownership and tunne…

### DIFF
--- a/.claude/skills/dockroute-dev-practices/SKILL.md
+++ b/.claude/skills/dockroute-dev-practices/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: dockroute-dev-practices
+description: Development best practices for the dockroute codebase (Bun + TypeScript) — SOLID applied to the provider architecture, anti-corruption layer rules for external APIs (DNS providers, Docker Engine), and bun:test unit-testing patterns. Use this skill whenever writing or reviewing code in this repo — new providers, core changes, refactors, or tests — even if the user doesn't mention "best practices" explicitly.
+---
+
+# DockRoute Development Practices
+
+DockRoute's core promise is being provider-agnostic: many DNS providers, one
+core. Everything in this skill exists to protect that promise. Read
+`ARCHITECTURE.md` first if you haven't.
+
+## Anti-corruption layer (ACL) — the most important rule
+
+The core domain model lives in `src/core/types.ts` (`DnsRecord`, etc.).
+External systems — DNS provider APIs, the Docker Engine API — each have their
+own vocabulary and payload shapes. Those shapes must NEVER leak into `src/core/`.
+
+- Each provider translates between its wire format and `DnsRecord` **at its own
+  boundary**, inside `src/providers/<name>.ts` (or `src/providers/<name>/`).
+  Wire types (e.g. a Cloudflare API response interface) are declared there,
+  not exported to the core.
+- The same applies to Docker: raw Engine API payload types stay in
+  `src/docker/`; the core consumes only domain types.
+- If the core needs new information (e.g. record priority for MX), extend the
+  domain model deliberately in `src/core/types.ts` — never by passing a
+  provider's raw object through.
+- Smell test: `src/core/` must compile with every file in `src/providers/`
+  (except `provider.ts`) and `src/docker/client.ts` deleted. Imports only flow
+  inward: providers/docker → core, never core → providers.
+
+Why: the day a provider's API shape drives a core type, every other provider
+inherits that provider's quirks, and adding provider N+1 means touching the core.
+
+## SOLID, applied to this codebase
+
+Don't recite SOLID — apply it where it pays off here:
+
+- **S**: one module, one reason to change. Label parsing (`core/labels.ts`),
+  reconciling (`core/reconciler.ts`), Docker transport (`docker/client.ts`) and
+  provider logic stay separate. If a change to a provider forces edits in two
+  of these, the boundary is wrong.
+- **O**: new providers are added by creating a file and calling
+  `registerProvider()` — never by editing a switch/if-chain in the core. Keep
+  it that way for new extension points too (e.g. record sources beyond labels).
+- **L**: every provider must be substitutable. If code somewhere does
+  `if (provider.name === "cloudflare")`, the `Provider` interface is missing a
+  capability — extend the interface instead.
+- **I**: keep the `Provider` interface minimal. Optional capabilities
+  (dry-run, batch limits, zone filtering) go in as optional members or
+  separate small interfaces, not mandatory methods every provider must stub.
+- **D**: the core depends on the `Provider` abstraction and receives
+  dependencies via constructor (see `Reconciler`). Never `new` a concrete
+  provider or Docker client inside core logic — wiring happens in
+  `src/index.ts` only.
+
+## Unit testing patterns (bun:test)
+
+- Tests live next to the code: `foo.ts` → `foo.test.ts`. Run with `bun test`.
+- Use `import { describe, test, expect } from "bun:test"`.
+- Structure each test as Arrange–Act–Assert; name tests after behavior, not
+  implementation: `test("skips containers without dockroute.enabled")`, not
+  `test("recordsFromContainer returns []")`.
+- **Prefer hand-written fakes over mocking frameworks.** The interfaces are
+  small by design — a fake `Provider` that records the `DnsRecord[]` it
+  received, or a fake Docker client returning canned `ContainerInfo[]`, is a
+  few lines and keeps tests readable. See `src/core/labels.test.ts` for the
+  house style, including small builder helpers like `container(labels)`.
+- Test through public interfaces; don't export private helpers just to test
+  them. If a helper is hard to reach, that's a design signal.
+- Every provider needs contract-style tests: given a desired `DnsRecord[]`,
+  assert the provider performs the right creates/updates/deletes against a
+  fake of its API. Never hit real APIs in unit tests.
+- Cover the unhappy paths that matter operationally: malformed labels,
+  provider API errors, empty desired state (which implies deletions).
+
+## Bun & TypeScript conventions
+
+- Follow the root `CLAUDE.md`: Bun APIs over Node equivalents (`Bun.file`,
+  `fetch` with `unix:`, `Bun.sleep`), no express/ws/dotenv.
+- `strict` TypeScript; no `any` at boundaries — model wire payloads with
+  explicit interfaces and validate/narrow at the edge (the ACL boundary is
+  exactly where unknown data gets checked).
+- Errors from external systems are expected, not exceptional: catch at the
+  boundary, log with a `[component]` prefix (existing style), and keep the
+  reconcile loop alive. Only configuration errors at startup may crash.
+- Run `bun run typecheck` and `bun test` before considering any change done.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Something misbehaved — a record wrongly created/deleted, a crash, a conflict not detected
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: labels-config
+    attributes:
+      label: Container labels and DockRoute configuration
+      description: The dockroute.* labels involved and relevant env vars (NEVER paste your API token).
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant dockroute output (the `[reconciler]` / `[cloudflare]` / `[labels]` lines).
+      render: text
+
+  - type: input
+    id: version
+    attributes:
+      label: DockRoute version / image tag
+      placeholder: e.g. v0.1.0, main@d3e2ad6
+    validations:
+      required: true
+
+  - type: input
+    id: runtime
+    attributes:
+      label: Runtime
+      placeholder: e.g. Docker 29.6 / Podman 5.x, provider=cloudflare, policy=sync

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Propose a new capability (provider, label, policy, ...)
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the use case, not only the solution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: How would it look in labels / env vars? What should happen on conflicts?
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## What & why
+
+<!-- What does this change, and what problem does it solve? -->
+
+## Checklist
+
+- [ ] `bun test`, `bun run typecheck` and `bun run lint` pass locally
+- [ ] Tests added/updated for the change (in-memory fakes, no real HTTP)
+- [ ] Ownership/conflict safety rules unaffected — or the change to them is called out explicitly
+- [ ] Docs updated (README / ARCHITECTURE) if labels, env vars or behavior changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     name: Docker build & scan
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       security-events: write
     steps:
@@ -63,7 +64,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: dockroute:ci
           format: sarif
@@ -79,7 +80,7 @@ jobs:
           category: trivy-image
 
       - name: Fail on fixable CRITICAL/HIGH vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: dockroute:ci
           format: table

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Lint, typecheck & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,21 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
-      - name: Test
-        run: bun test
+      - name: Test (with coverage)
+        run: bun test --coverage --coverage-reporter=lcov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage/lcov.info
+          fail_ci_if_error: false
 
   docker:
-    name: Docker build
+    name: Docker build & scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
@@ -48,5 +57,32 @@ jobs:
         with:
           context: .
           push: false
+          load: true
+          tags: dockroute:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: dockroute:ci
+          format: sarif
+          output: trivy.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy.sarif
+          category: trivy-image
+
+      - name: Fail on fixable CRITICAL/HIGH vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: dockroute:ci
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,7 @@ jobs:
     name: Analyze TypeScript
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       security-events: write
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 6 * * 1" # weekly, Monday 06:17 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze TypeScript
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/dockroute
+
+jobs:
+  verify:
+    name: Lint, typecheck & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+  publish:
+    name: Publish image to GHCR
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push (amd64 + arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create release with generated notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build local image for scan
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: dockroute:release-scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy (gate)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: dockroute:release-scan
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+
       - name: Image metadata
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image with Trivy (gate)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: dockroute:release-scan
           format: table

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,187 @@
+# DockRoute — Architecture
+
+DockRoute watches running Docker containers, reads `dockroute.*` labels
+(annotations) and reconciles them against a pluggable DNS provider —
+the same idea as Kubernetes [external-dns](https://github.com/kubernetes-sigs/external-dns),
+but for plain Docker hosts.
+
+The central principle:
+
+> **DockRoute never alters what it cannot prove it manages.**
+
+## High-level flow
+
+```mermaid
+flowchart LR
+    D[Docker Engine API\n/var/run/docker.sock] -->|events + list| W[Watcher]
+    W --> P[Label Parser]
+    P --> S[Desired State\nDNS records + tunnel routes]
+    S --> R[Reconciler]
+    R -->|sync| DNS[(DNS Provider\nlog / cloudflare / ...)]
+```
+
+1. **Watcher** (`src/docker/watcher.ts`) — connects to the Docker socket
+   (Bun's `fetch` supports `unix:` sockets natively). On startup it lists all
+   running containers; afterwards it streams `/events` (container `start`,
+   `die`, `stop`) and triggers a reconciliation on every relevant event.
+   A periodic full re-list acts as a safety net against missed events.
+2. **Label Parser** (`src/core/labels.ts`) — extracts `dockroute.*` labels
+   from each container and turns them into a desired state: plain
+   `DnsRecord`s or `TunnelRoute`s. Containers without
+   `dockroute.enabled=true` are ignored.
+3. **Reconciler** (`src/core/reconciler.ts`) — merges the desired state from
+   *all* running containers (deduplicating hostnames — first container wins)
+   and hands it to the provider. The provider owns the diff
+   (create / update / delete).
+4. **Provider** (`src/providers/`) — one interface, many implementations:
+   - `log` — dry-run, prints the desired state. Default; lets the whole
+     pipeline run with zero credentials.
+   - `cloudflare` — DNS records + Cloudflare Tunnel ingress routes, with
+     TXT-based ownership.
+   - `route53`, `rfc2136`, `pihole`, ... — future.
+
+## Ownership (TXT registry)
+
+Modeled after ExternalDNS's TXT registry. Every data record DockRoute
+creates gets a companion TXT record:
+
+- **Name:** `<txt-prefix><record-type>.<hostname>` — e.g. the A record for
+  `whoami.example.com` is tracked by `_dockroute-a.whoami.example.com`.
+  The prefix avoids CNAME-coexistence issues and the embedded type
+  disambiguates multiple record types at the same name.
+- **Content:** `heritage=dockroute,dockroute/owner=<owner-id>[,dockroute/resource=container/<id>]`
+
+A record is *owned* only when its companion TXT exists, carries
+`heritage=dockroute` and the matching `dockroute/owner`. The rules, enforced
+by the provider-agnostic planner (`src/providers/registry/planner.ts`):
+
+- Existing record with no ownership TXT → **conflict**: logged and skipped,
+  never modified, never adopted.
+- Existing record owned by another owner id → conflict, skipped. Multiple
+  DockRoute instances can safely share one zone with distinct
+  `DOCKROUTE_OWNER_ID`s.
+- Orphaned records (owner's container is gone) are deleted **only** under
+  the `sync` policy and only when ownership is proven.
+- Dangling ownership TXT (data record manually deleted): recreate the record
+  if still desired, clean up the TXT under `sync` if not.
+
+## Sync policies
+
+`DOCKROUTE_POLICY`, same semantics as ExternalDNS:
+
+| Policy | Creates | Updates owned | Deletes owned orphans |
+| ------------- | ------- | ------------- | --------------------- |
+| `sync` (default) | ✓ | ✓ | ✓ |
+| `upsert-only` | ✓ | ✓ | — |
+| `create-only` | ✓ | — | — |
+
+Conflicts (anything not owned) are never touched under any policy.
+
+## Cloudflare Tunnel (existing-tunnel model)
+
+DockRoute does **not** create tunnels or move traffic — you create the tunnel
+and run `cloudflared`; DockRoute manages, via the Cloudflare API:
+
+1. the **public-hostname ingress rules** in the tunnel's remotely-managed
+   configuration, and
+2. the proxied **CNAME records** pointing each hostname at
+   `<tunnel-id>.cfargotunnel.com`.
+
+A container opts in with `dockroute.tunnel.service` (e.g. `http://whoami:80`).
+Tunnel mode takes precedence over plain `dockroute.type`/`dockroute.target`.
+
+Safety around the tunnel configuration endpoint (the PUT replaces the whole
+ingress list):
+
+- An ingress rule is *managed* iff its hostname is proven ours through the
+  TXT registry (owned CNAME pointing at the tunnel domain). Everything else
+  is preserved verbatim, in its original order, ahead of managed rules — a
+  pre-existing rule never starts being shadowed by ours.
+- An unmanaged rule already claiming a desired hostname is a conflict:
+  logged and skipped.
+- The catch-all rule (last, no hostname) is always preserved; a fresh ingress
+  gets `http_status:404`.
+- The configuration is re-read immediately before writing and only written
+  when it actually changed. The endpoint is last-writer-wins, so DockRoute
+  assumes it is the **only automated writer** for the tunnels it manages.
+
+## Label schema
+
+| Label                        | Required | Default                    | Description                                  |
+| ---------------------------- | -------- | -------------------------- | -------------------------------------------- |
+| `dockroute.enabled`          | yes      | —                          | `true` opts the container in                 |
+| `dockroute.hostname`         | yes      | —                          | FQDN(s), comma-separated                     |
+| `dockroute.type`             | no       | `A`                        | `A`, `AAAA` or `CNAME`                       |
+| `dockroute.target`           | no       | `DOCKROUTE_DEFAULT_TARGET` | Record value (IP or CNAME target)            |
+| `dockroute.ttl`              | no       | `300`                      | Record TTL in seconds                        |
+| `dockroute.tunnel.service`   | no       | —                          | Origin URL (`http://svc:port`); switches the container to tunnel publishing |
+| `dockroute.cloudflare.proxied` | no     | `false`                    | Serve plain records through Cloudflare's proxy |
+
+Example:
+
+```yaml
+services:
+  whoami:
+    image: traefik/whoami
+    labels:
+      dockroute.enabled: "true"
+      dockroute.hostname: "whoami.example.com"
+      dockroute.tunnel.service: "http://whoami:80"
+```
+
+## Configuration (environment variables)
+
+| Variable                   | Default                | Description                             |
+| -------------------------- | ---------------------- | --------------------------------------- |
+| `DOCKER_SOCK`              | `/var/run/docker.sock` | Docker Engine socket path               |
+| `DOCKROUTE_PROVIDER`       | `log`                  | DNS provider to use                     |
+| `DOCKROUTE_DEFAULT_TARGET` | —                      | Fallback target when label is omitted   |
+| `DOCKROUTE_RESYNC_SECONDS` | `60`                   | Interval of the periodic full reconcile |
+| `DOCKROUTE_OWNER_ID`       | `default`              | Ownership id written into registry TXTs |
+| `DOCKROUTE_POLICY`         | `sync`                 | `sync`, `upsert-only` or `create-only`  |
+| `DOCKROUTE_TXT_PREFIX`     | `_dockroute-`          | Registry TXT name prefix                |
+| `DOCKROUTE_DOMAIN_FILTER`  | —                      | Comma-separated zone allowlist          |
+| `CLOUDFLARE_API_TOKEN`     | —                      | Required for `cloudflare`. Scopes: Zone → DNS → Edit; Account → Cloudflare Tunnel → Edit (tunnel only) |
+| `CLOUDFLARE_ACCOUNT_ID`    | —                      | Required for tunnel features            |
+| `CLOUDFLARE_TUNNEL_ID`     | —                      | Required for tunnel features            |
+
+## Source layout
+
+```
+src/
+  index.ts              entrypoint — wiring only
+  config.ts             env-based configuration (policy validation lives here)
+  docker/
+    client.ts           minimal Docker Engine API client (unix socket)
+    watcher.ts          event stream + periodic resync → triggers reconcile
+  core/
+    types.ts            DnsRecord, TunnelRoute, DesiredState, ContainerInfo
+    labels.ts           dockroute.* label parsing → DesiredState
+    reconciler.ts       desired state merge/dedupe → provider.sync()
+  providers/
+    provider.ts         Provider interface + registry
+    log.ts              dry-run provider (default)
+    registry/
+      ownership.ts      TXT ownership format + naming (provider-agnostic)
+      planner.ts        pure reconciliation planner: policies, conflicts, orphans
+    cloudflare/
+      api.ts            Cloudflare v4 wire client (wire types stay here — ACL)
+      cloudflare.ts     provider: zones, planner execution, TTL normalization
+      tunnel.ts         pure ingress merge (managed/unmanaged/catch-all)
+```
+
+## Design decisions
+
+- **Full-state sync, not incremental patches.** Every reconcile recomputes
+  the complete desired set from the Docker API and syncs it. Simpler,
+  self-healing, and events only decide *when* to reconcile, never *what*.
+- **Provider owns the diff, planner owns the rules.** The ownership/policy
+  logic is provider-agnostic (`src/providers/registry/`); each provider maps
+  its wire format at its own boundary and never leaks it into `src/core/`
+  (anti-corruption layer).
+- **No database.** Docker is the source of truth for desired state; the DNS
+  provider plus the TXT registry is the source of truth for actual state and
+  ownership. The container stays stateless and disposable.
+- **Proxied TTL normalization.** Cloudflare forces TTL `1` (auto) on proxied
+  records; both sides are normalized before diffing so reconciles converge
+  instead of issuing no-op updates forever.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+
+Default to using Bun instead of Node.js.
+
+- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
+- Use `bun test` instead of `jest` or `vitest`
+- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
+- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
+- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
+- Use `bunx <package> <command>` instead of `npx <package> <command>`
+- Bun automatically loads .env, so don't use dotenv.
+
+## APIs
+
+- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
+- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
+- `Bun.redis` for Redis. Don't use `ioredis`.
+- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
+- `WebSocket` is built-in. Don't use `ws`.
+- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
+- Bun.$`ls` instead of execa.
+
+## Testing
+
+Use `bun test` to run tests.
+
+```ts#index.test.ts
+import { test, expect } from "bun:test";
+
+test("hello world", () => {
+  expect(1).toBe(1);
+});
+```
+
+## Frontend
+
+Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
+
+Server:
+
+```ts#index.ts
+import index from "./index.html"
+
+Bun.serve({
+  routes: {
+    "/": index,
+    "/api/users/:id": {
+      GET: (req) => {
+        return new Response(JSON.stringify({ id: req.params.id }));
+      },
+    },
+  },
+  // optional websocket support
+  websocket: {
+    open: (ws) => {
+      ws.send("Hello, world!");
+    },
+    message: (ws, message) => {
+      ws.send(message);
+    },
+    close: (ws) => {
+      // handle close
+    }
+  },
+  development: {
+    hmr: true,
+    console: true,
+  }
+})
+```
+
+HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
+
+```html#index.html
+<html>
+  <body>
+    <h1>Hello, world!</h1>
+    <script type="module" src="./frontend.tsx"></script>
+  </body>
+</html>
+```
+
+With the following `frontend.tsx`:
+
+```tsx#frontend.tsx
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+// import .css files directly and it works
+import './index.css';
+
+const root = createRoot(document.body);
+
+export default function Frontend() {
+  return <h1>Hello, world!</h1>;
+}
+
+root.render(<Frontend />);
+```
+
+Then, run index.ts
+
+```sh
+bun --hot ./index.ts
+```
+
+For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to DockRoute
+
+Thanks for your interest! Contributions of all kinds are welcome: bug
+reports, docs, code and design discussions.
+
+## Development setup
+
+DockRoute runs on [Bun](https://bun.sh) (no Node.js needed):
+
+```sh
+bun install
+bun test            # unit tests
+bun run typecheck   # strict TypeScript
+bun run lint        # Biome (bun run lint:fix to auto-fix)
+bun start           # run against your local Docker socket (provider=log)
+```
+
+All four must pass before a PR — CI enforces them.
+
+## Ground rules
+
+- **`main` stays clean** — all changes land via pull request.
+- **The safety principle is non-negotiable:** DockRoute never modifies or
+  deletes anything it cannot prove it manages (see
+  [ARCHITECTURE.md](ARCHITECTURE.md)). PRs that weaken ownership or conflict
+  checks will be asked to rework.
+- **Anti-corruption layer:** provider wire types (Cloudflare payloads, Docker
+  Engine payloads) never leak into `src/core/`. Each provider translates at
+  its own boundary. `src/core/` must compile with every provider deleted.
+- **Tests come with the change:** new providers need contract-style tests
+  against an in-memory fake of their API — unit tests never hit real HTTP.
+  House style: hand-written fakes, Arrange–Act–Assert, behavior-named tests
+  (see `src/core/labels.test.ts`).
+- English only in code, comments, commits and docs.
+
+## Adding a DNS provider
+
+1. Create `src/providers/<name>/` with the wire client and the provider.
+2. Reuse `src/providers/registry/` (ownership + planner) — the safety rules
+   live there and must behave identically across providers.
+3. Register via `registerProvider("<name>", (config) => ...)` — no
+   switch/if-chains in the core.
+4. Import it in `src/index.ts` and document labels/env vars in the README.
+
+## Commit / PR conventions
+
+- Conventional-style prefixes appreciated: `feat:`, `fix:`, `docs:`,
+  `chore:`, `test:`.
+- Keep PRs focused; describe *why*, not just *what*.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1 AS base
+WORKDIR /app
+
+FROM base AS install
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+FROM base AS release
+COPY --from=install /app/node_modules ./node_modules
+COPY package.json ./
+COPY src ./src
+
+USER bun
+ENTRYPOINT ["bun", "run", "src/index.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --production
 
 FROM base AS release
+# Apply Debian security updates so the image doesn't ship known-fixed CVEs
+RUN apt-get update \
+  && apt-get upgrade -y --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
 COPY --from=install /app/node_modules ./node_modules
 COPY package.json ./
 COPY src ./src

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # dockroute
 
+[![CI](https://github.com/Dockroute/Dockroute/actions/workflows/ci.yml/badge.svg)](https://github.com/Dockroute/Dockroute/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/Dockroute/Dockroute?include_prereleases)](https://github.com/Dockroute/Dockroute/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 External-DNS for plain Docker hosts: dockroute watches your running
 containers, reads `dockroute.*` labels and reconciles the matching DNS
 records — and Cloudflare Tunnel routes — in a pluggable provider.
@@ -31,7 +35,7 @@ Run dockroute next to it:
 ```yaml
 services:
   dockroute:
-    image: dockroute # build locally for now: docker build -t dockroute .
+    image: ghcr.io/dockroute/dockroute:latest
     environment:
       DOCKROUTE_PROVIDER: cloudflare
       DOCKROUTE_OWNER_ID: home-lab
@@ -41,6 +45,10 @@ services:
       CLOUDFLARE_TUNNEL_ID: ${CLOUDFLARE_TUNNEL_ID}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    # the image runs as a non-root user; grant it the host's docker group
+    # to read the socket:  stat -c '%g' /var/run/docker.sock
+    group_add:
+      - "990"
 ```
 
 Or start with the zero-credential dry run:
@@ -93,9 +101,13 @@ DOCKROUTE_DEFAULT_TARGET=192.168.1.10 bun start   # provider=log by default
 
 ```sh
 bun install
-bun test
-bun run typecheck
+bun test            # unit tests (in-memory fakes, no real HTTP)
+bun run typecheck   # strict TypeScript
+bun run lint        # Biome — bun run lint:fix to auto-fix
 ```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the ground rules (ownership
+safety, anti-corruption layer, testing style) and how to add a provider.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# dockroute
+
+External-DNS for plain Docker hosts: dockroute watches your running
+containers, reads `dockroute.*` labels and reconciles the matching DNS
+records — and Cloudflare Tunnel routes — in a pluggable provider.
+
+Your Docker Compose file is the source of truth; dockroute makes the
+provider match it, and **never alters what it cannot prove it manages**
+(ExternalDNS-style TXT ownership).
+
+> Status: MVP + Cloudflare. DNS records, TXT ownership, sync policies and
+> Cloudflare Tunnel routes work end to end. See [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Quick start
+
+Label a container:
+
+```yaml
+services:
+  whoami:
+    image: traefik/whoami
+    labels:
+      dockroute.enabled: "true"
+      dockroute.hostname: "whoami.example.com"
+      # publish through an existing Cloudflare Tunnel:
+      dockroute.tunnel.service: "http://whoami:80"
+```
+
+Run dockroute next to it:
+
+```yaml
+services:
+  dockroute:
+    image: dockroute # build locally for now: docker build -t dockroute .
+    environment:
+      DOCKROUTE_PROVIDER: cloudflare
+      DOCKROUTE_OWNER_ID: home-lab
+      CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN}
+      # only needed for tunnel publishing:
+      CLOUDFLARE_ACCOUNT_ID: ${CLOUDFLARE_ACCOUNT_ID}
+      CLOUDFLARE_TUNNEL_ID: ${CLOUDFLARE_TUNNEL_ID}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+```
+
+Or start with the zero-credential dry run:
+
+```sh
+bun install
+DOCKROUTE_DEFAULT_TARGET=192.168.1.10 bun start   # provider=log by default
+```
+
+## Labels
+
+| Label                          | Required | Default                    | Description                       |
+| ------------------------------ | -------- | -------------------------- | --------------------------------- |
+| `dockroute.enabled`            | yes      | —                          | `true` opts the container in      |
+| `dockroute.hostname`           | yes      | —                          | FQDN(s), comma-separated          |
+| `dockroute.type`               | no       | `A`                        | `A`, `AAAA` or `CNAME`            |
+| `dockroute.target`             | no       | `DOCKROUTE_DEFAULT_TARGET` | Record value (IP or CNAME target) |
+| `dockroute.ttl`                | no       | `300`                      | TTL in seconds                    |
+| `dockroute.tunnel.service`     | no       | —                          | Origin URL; publish via Cloudflare Tunnel instead of a plain record |
+| `dockroute.cloudflare.proxied` | no       | `false`                    | Proxy plain records through Cloudflare |
+
+## Configuration
+
+| Variable                   | Default                | Description                             |
+| -------------------------- | ---------------------- | --------------------------------------- |
+| `DOCKER_SOCK`              | `/var/run/docker.sock` | Docker Engine socket path               |
+| `DOCKROUTE_PROVIDER`       | `log`                  | `log` (dry-run) or `cloudflare`         |
+| `DOCKROUTE_DEFAULT_TARGET` | —                      | Fallback target when label is omitted   |
+| `DOCKROUTE_RESYNC_SECONDS` | `60`                   | Interval of the periodic full reconcile |
+| `DOCKROUTE_OWNER_ID`       | `default`              | Ownership id — lets several instances share a zone safely |
+| `DOCKROUTE_POLICY`         | `sync`                 | `sync`, `upsert-only` or `create-only`  |
+| `DOCKROUTE_TXT_PREFIX`     | `_dockroute-`          | Ownership TXT name prefix               |
+| `DOCKROUTE_DOMAIN_FILTER`  | —                      | Comma-separated zone allowlist          |
+| `CLOUDFLARE_API_TOKEN`     | —                      | Token with Zone→DNS→Edit (+ Account→Cloudflare Tunnel→Edit for tunnels) |
+| `CLOUDFLARE_ACCOUNT_ID`    | —                      | For tunnel publishing                   |
+| `CLOUDFLARE_TUNNEL_ID`     | —                      | For tunnel publishing (existing tunnel, you run `cloudflared`) |
+
+## Safety model
+
+- Every record dockroute creates gets a companion TXT record
+  (`_dockroute-a.whoami.example.com`) carrying its owner id.
+- Records without that proof of ownership are **never** modified, deleted or
+  adopted — conflicts are logged and skipped.
+- Orphan cleanup (container gone → records removed) only happens under the
+  default `sync` policy and only for records this instance owns.
+- Tunnel ingress rules that dockroute did not create are preserved verbatim;
+  dockroute assumes it is the only automated writer for the tunnels it manages.
+
+## Development
+
+```sh
+bun install
+bun test
+bun run typecheck
+```
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # dockroute
 
 [![CI](https://github.com/Dockroute/Dockroute/actions/workflows/ci.yml/badge.svg)](https://github.com/Dockroute/Dockroute/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/Dockroute/Dockroute/actions/workflows/codeql.yml/badge.svg)](https://github.com/Dockroute/Dockroute/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/Dockroute/Dockroute/branch/main/graph/badge.svg)](https://codecov.io/gh/Dockroute/Dockroute)
 [![Release](https://img.shields.io/github/v/release/Dockroute/Dockroute?include_prereleases)](https://github.com/Dockroute/Dockroute/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+DockRoute handles DNS provider credentials and talks to the Docker socket,
+so we take reports seriously.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for security problems. Instead use
+GitHub's private vulnerability reporting
+(*Security → Report a vulnerability* on the repository), or email
+`danilo.dorgam@codeinloop.com.br`.
+
+You can expect an acknowledgement within a few days. Please include steps to
+reproduce and the impact you foresee.
+
+## Scope notes
+
+- DockRoute needs read-only access to the Docker socket (`:ro` mount) and a
+  DNS provider token. Grant the token the minimum scopes documented in the
+  README (Zone → DNS → Edit; Account → Cloudflare Tunnel → Edit only when
+  using tunnels).
+- DockRoute never stores credentials; they are read from environment
+  variables at startup.
+
+## Supported versions
+
+Pre-1.0: only the latest release receives fixes.

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["src/**", "*.json"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "suspicious": {
+        "noConsole": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all"
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,26 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "dockroute",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "dockroute",
       "devDependencies": {
+        "@biomejs/biome": "^2.5.5",
         "@types/bun": "latest",
       },
       "peerDependencies": {
@@ -13,6 +14,24 @@
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "dockroute",
+  "version": "0.1.0",
+  "description": "External-DNS for plain Docker hosts: registers DNS records from container labels",
+  "license": "MIT",
+  "module": "src/index.ts",
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "dev": "bun run --watch src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "start": "bun run src/index.ts",
     "dev": "bun run --watch src/index.ts",
     "typecheck": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write ."
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.5.5",
     "@types/bun": "latest"
   },
   "peerDependencies": {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -21,7 +21,9 @@ describe("loadConfig", () => {
   });
 
   test("rejects an invalid policy", () => {
-    expect(() => loadConfig({ DOCKROUTE_POLICY: "delete-everything" })).toThrow(/Invalid DOCKROUTE_POLICY/);
+    expect(() => loadConfig({ DOCKROUTE_POLICY: "delete-everything" })).toThrow(
+      /Invalid DOCKROUTE_POLICY/,
+    );
   });
 
   test("parses the domain filter as a trimmed list", () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { loadConfig } from "./config";
+
+describe("loadConfig", () => {
+  test("applies defaults", () => {
+    const config = loadConfig({});
+    expect(config).toMatchObject({
+      provider: "log",
+      policy: "sync",
+      ownerId: "default",
+      txtPrefix: "_dockroute-",
+      domainFilter: [],
+      resyncSeconds: 60,
+    });
+  });
+
+  test("accepts every valid policy", () => {
+    for (const policy of ["sync", "upsert-only", "create-only"]) {
+      expect(loadConfig({ DOCKROUTE_POLICY: policy }).policy).toBe(policy as never);
+    }
+  });
+
+  test("rejects an invalid policy", () => {
+    expect(() => loadConfig({ DOCKROUTE_POLICY: "delete-everything" })).toThrow(/Invalid DOCKROUTE_POLICY/);
+  });
+
+  test("parses the domain filter as a trimmed list", () => {
+    const config = loadConfig({ DOCKROUTE_DOMAIN_FILTER: "example.com, example.org ," });
+    expect(config.domainFilter).toEqual(["example.com", "example.org"]);
+  });
+
+  test("requires an API token for the cloudflare provider", () => {
+    expect(() => loadConfig({ DOCKROUTE_PROVIDER: "cloudflare" })).toThrow(/CLOUDFLARE_API_TOKEN/);
+    const config = loadConfig({
+      DOCKROUTE_PROVIDER: "cloudflare",
+      CLOUDFLARE_API_TOKEN: "token",
+      CLOUDFLARE_ACCOUNT_ID: "acc",
+      CLOUDFLARE_TUNNEL_ID: "tun",
+    });
+    expect(config.cloudflare).toEqual({ apiToken: "token", accountId: "acc", tunnelId: "tun" });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,55 @@
+export const POLICIES = ["sync", "upsert-only", "create-only"] as const;
+export type Policy = (typeof POLICIES)[number];
+
+export interface CloudflareConfig {
+  apiToken?: string;
+  accountId?: string;
+  tunnelId?: string;
+}
+
+export interface Config {
+  dockerSock: string;
+  provider: string;
+  defaultTarget?: string;
+  resyncSeconds: number;
+  ownerId: string;
+  policy: Policy;
+  txtPrefix: string;
+  /** Optional allowlist of zones DockRoute may touch. Empty = all. */
+  domainFilter: string[];
+  cloudflare: CloudflareConfig;
+}
+
+export function loadConfig(env = process.env): Config {
+  const policy = env.DOCKROUTE_POLICY ?? "sync";
+  if (!POLICIES.includes(policy as Policy)) {
+    throw new Error(
+      `Invalid DOCKROUTE_POLICY "${policy}". Valid values: ${POLICIES.join(", ")}`,
+    );
+  }
+
+  const provider = env.DOCKROUTE_PROVIDER ?? "log";
+  const cloudflare: CloudflareConfig = {
+    apiToken: env.CLOUDFLARE_API_TOKEN,
+    accountId: env.CLOUDFLARE_ACCOUNT_ID,
+    tunnelId: env.CLOUDFLARE_TUNNEL_ID,
+  };
+  if (provider === "cloudflare" && !cloudflare.apiToken) {
+    throw new Error("CLOUDFLARE_API_TOKEN is required when DOCKROUTE_PROVIDER=cloudflare");
+  }
+
+  return {
+    dockerSock: env.DOCKER_SOCK ?? "/var/run/docker.sock",
+    provider,
+    defaultTarget: env.DOCKROUTE_DEFAULT_TARGET,
+    resyncSeconds: Number(env.DOCKROUTE_RESYNC_SECONDS ?? 60),
+    ownerId: env.DOCKROUTE_OWNER_ID ?? "default",
+    policy: policy as Policy,
+    txtPrefix: env.DOCKROUTE_TXT_PREFIX ?? "_dockroute-",
+    domainFilter: (env.DOCKROUTE_DOMAIN_FILTER ?? "")
+      .split(",")
+      .map((d) => d.trim())
+      .filter(Boolean),
+    cloudflare,
+  };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,9 +23,7 @@ export interface Config {
 export function loadConfig(env = process.env): Config {
   const policy = env.DOCKROUTE_POLICY ?? "sync";
   if (!POLICIES.includes(policy as Policy)) {
-    throw new Error(
-      `Invalid DOCKROUTE_POLICY "${policy}". Valid values: ${POLICIES.join(", ")}`,
-    );
+    throw new Error(`Invalid DOCKROUTE_POLICY "${policy}". Valid values: ${POLICIES.join(", ")}`);
   }
 
   const provider = env.DOCKROUTE_PROVIDER ?? "log";

--- a/src/core/labels.test.ts
+++ b/src/core/labels.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import type { ContainerInfo } from "./types";
+import { desiredFromContainer } from "./labels";
+
+function container(labels: Record<string, string>): ContainerInfo {
+  return { Id: "abc123def4567890", Names: ["/whoami"], Labels: labels, State: "running" };
+}
+
+const empty = { records: [], tunnelRoutes: [] };
+
+describe("desiredFromContainer", () => {
+  test("ignores containers without dockroute.enabled", () => {
+    expect(desiredFromContainer(container({}))).toEqual(empty);
+    expect(desiredFromContainer(container({ "dockroute.hostname": "a.example.com" }))).toEqual(empty);
+  });
+
+  test("builds an A record with defaults", () => {
+    const { records } = desiredFromContainer(
+      container({ "dockroute.enabled": "true", "dockroute.hostname": "a.example.com" }),
+      { defaultTarget: "192.168.1.10" },
+    );
+    expect(records).toEqual([
+      { hostname: "a.example.com", type: "A", target: "192.168.1.10", ttl: 300, source: "abc123def4567890" },
+    ]);
+  });
+
+  test("supports multiple comma-separated hostnames", () => {
+    const { records } = desiredFromContainer(
+      container({
+        "dockroute.enabled": "true",
+        "dockroute.hostname": "a.example.com, b.example.com",
+        "dockroute.target": "10.0.0.1",
+      }),
+    );
+    expect(records.map((r) => r.hostname)).toEqual(["a.example.com", "b.example.com"]);
+  });
+
+  test("honours explicit type, target and ttl", () => {
+    const [record] = desiredFromContainer(
+      container({
+        "dockroute.enabled": "true",
+        "dockroute.hostname": "cname.example.com",
+        "dockroute.type": "cname",
+        "dockroute.target": "origin.example.com",
+        "dockroute.ttl": "60",
+      }),
+    ).records;
+    expect(record).toMatchObject({ type: "CNAME", target: "origin.example.com", ttl: 60 });
+  });
+
+  test("skips when no target is resolvable or type is unsupported", () => {
+    expect(
+      desiredFromContainer(container({ "dockroute.enabled": "true", "dockroute.hostname": "a.example.com" })),
+    ).toEqual(empty);
+    expect(
+      desiredFromContainer(
+        container({
+          "dockroute.enabled": "true",
+          "dockroute.hostname": "a.example.com",
+          "dockroute.type": "MX",
+          "dockroute.target": "10.0.0.1",
+        }),
+      ),
+    ).toEqual(empty);
+  });
+
+  test("passes provider-specific labels through", () => {
+    const [record] = desiredFromContainer(
+      container({
+        "dockroute.enabled": "true",
+        "dockroute.hostname": "a.example.com",
+        "dockroute.target": "10.0.0.1",
+        "dockroute.cloudflare.proxied": "true",
+      }),
+    ).records;
+    expect(record?.providerSpecific).toEqual({ "cloudflare.proxied": "true" });
+  });
+
+  test("builds tunnel routes for every hostname when tunnel.service is set", () => {
+    const state = desiredFromContainer(
+      container({
+        "dockroute.enabled": "true",
+        "dockroute.hostname": "a.example.com, b.example.com",
+        "dockroute.tunnel.service": "http://whoami:8080",
+      }),
+    );
+    expect(state.records).toEqual([]);
+    expect(state.tunnelRoutes).toEqual([
+      { hostname: "a.example.com", service: "http://whoami:8080", source: "abc123def4567890" },
+      { hostname: "b.example.com", service: "http://whoami:8080", source: "abc123def4567890" },
+    ]);
+  });
+
+  test("tunnel mode wins over dockroute.type/target", () => {
+    const state = desiredFromContainer(
+      container({
+        "dockroute.enabled": "true",
+        "dockroute.hostname": "a.example.com",
+        "dockroute.tunnel.service": "https://whoami:443",
+        "dockroute.type": "A",
+        "dockroute.target": "10.0.0.1",
+      }),
+    );
+    expect(state.records).toEqual([]);
+    expect(state.tunnelRoutes).toHaveLength(1);
+  });
+
+  test("skips invalid tunnel service URLs", () => {
+    for (const service of ["whoami:8080", "ftp://whoami:21", "not a url"]) {
+      expect(
+        desiredFromContainer(
+          container({
+            "dockroute.enabled": "true",
+            "dockroute.hostname": "a.example.com",
+            "dockroute.tunnel.service": service,
+          }),
+        ),
+      ).toEqual(empty);
+    }
+  });
+});

--- a/src/core/labels.test.ts
+++ b/src/core/labels.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { ContainerInfo } from "./types";
 import { desiredFromContainer } from "./labels";
+import type { ContainerInfo } from "./types";
 
 function container(labels: Record<string, string>): ContainerInfo {
   return { Id: "abc123def4567890", Names: ["/whoami"], Labels: labels, State: "running" };
@@ -11,7 +11,9 @@ const empty = { records: [], tunnelRoutes: [] };
 describe("desiredFromContainer", () => {
   test("ignores containers without dockroute.enabled", () => {
     expect(desiredFromContainer(container({}))).toEqual(empty);
-    expect(desiredFromContainer(container({ "dockroute.hostname": "a.example.com" }))).toEqual(empty);
+    expect(desiredFromContainer(container({ "dockroute.hostname": "a.example.com" }))).toEqual(
+      empty,
+    );
   });
 
   test("builds an A record with defaults", () => {
@@ -20,7 +22,13 @@ describe("desiredFromContainer", () => {
       { defaultTarget: "192.168.1.10" },
     );
     expect(records).toEqual([
-      { hostname: "a.example.com", type: "A", target: "192.168.1.10", ttl: 300, source: "abc123def4567890" },
+      {
+        hostname: "a.example.com",
+        type: "A",
+        target: "192.168.1.10",
+        ttl: 300,
+        source: "abc123def4567890",
+      },
     ]);
   });
 
@@ -50,7 +58,9 @@ describe("desiredFromContainer", () => {
 
   test("skips when no target is resolvable or type is unsupported", () => {
     expect(
-      desiredFromContainer(container({ "dockroute.enabled": "true", "dockroute.hostname": "a.example.com" })),
+      desiredFromContainer(
+        container({ "dockroute.enabled": "true", "dockroute.hostname": "a.example.com" }),
+      ),
     ).toEqual(empty);
     expect(
       desiredFromContainer(

--- a/src/core/labels.ts
+++ b/src/core/labels.ts
@@ -1,0 +1,129 @@
+import type { ContainerInfo, DesiredState, DnsRecord, RecordType } from "./types";
+
+const PREFIX = "dockroute.";
+const RECORD_TYPES: RecordType[] = ["A", "AAAA", "CNAME"];
+const DEFAULT_TTL = 300;
+const TUNNEL_SERVICE_SCHEMES = ["http:", "https:", "tcp:", "ssh:"];
+
+/** Label keys with a fixed meaning; everything else under dockroute.* with a
+ * dotted suffix (e.g. cloudflare.proxied) is passed through as a provider hint. */
+const KNOWN_KEYS = new Set(["enabled", "hostname", "type", "target", "ttl", "tunnel.service"]);
+
+export interface ParseOptions {
+  defaultTarget?: string;
+}
+
+export const emptyDesiredState = (): DesiredState => ({ records: [], tunnelRoutes: [] });
+
+/**
+ * Turns a container's dockroute.* labels into its desired state (DNS records
+ * or tunnel routes). Returns an empty state for containers that are not opted
+ * in or are misconfigured (misconfiguration is logged, never fatal).
+ */
+export function desiredFromContainer(
+  container: ContainerInfo,
+  opts: ParseOptions = {},
+): DesiredState {
+  const labels = container.Labels ?? {};
+  if (labels[`${PREFIX}enabled`] !== "true") return emptyDesiredState();
+
+  const name = container.Names?.[0] ?? container.Id.slice(0, 12);
+
+  const hostnames = (labels[`${PREFIX}hostname`] ?? "")
+    .split(",")
+    .map((h) => h.trim())
+    .filter(Boolean);
+  if (hostnames.length === 0) {
+    console.warn(`[labels] ${name}: dockroute.enabled but no dockroute.hostname, skipping`);
+    return emptyDesiredState();
+  }
+
+  const tunnelService = labels[`${PREFIX}tunnel.service`];
+  if (tunnelService !== undefined) {
+    return tunnelState(container, name, hostnames, tunnelService, labels);
+  }
+  return dnsState(container, name, hostnames, labels, opts);
+}
+
+function tunnelState(
+  container: ContainerInfo,
+  name: string,
+  hostnames: string[],
+  service: string,
+  labels: Record<string, string>,
+): DesiredState {
+  if (labels[`${PREFIX}type`] !== undefined || labels[`${PREFIX}target`] !== undefined) {
+    console.warn(
+      `[labels] ${name}: dockroute.tunnel.service set, ignoring dockroute.type/dockroute.target`,
+    );
+  }
+  if (!isValidServiceUrl(service)) {
+    console.warn(
+      `[labels] ${name}: invalid dockroute.tunnel.service "${service}" ` +
+        `(expected ${TUNNEL_SERVICE_SCHEMES.map((s) => s + "//").join(", ")}), skipping`,
+    );
+    return emptyDesiredState();
+  }
+
+  return {
+    records: [],
+    tunnelRoutes: hostnames.map((hostname) => ({
+      hostname,
+      service,
+      source: container.Id,
+    })),
+  };
+}
+
+function dnsState(
+  container: ContainerInfo,
+  name: string,
+  hostnames: string[],
+  labels: Record<string, string>,
+  opts: ParseOptions,
+): DesiredState {
+  const rawType = (labels[`${PREFIX}type`] ?? "A").toUpperCase();
+  if (!RECORD_TYPES.includes(rawType as RecordType)) {
+    console.warn(`[labels] ${name}: unsupported record type "${rawType}", skipping`);
+    return emptyDesiredState();
+  }
+
+  const target = labels[`${PREFIX}target`] ?? opts.defaultTarget;
+  if (!target) {
+    console.warn(`[labels] ${name}: no dockroute.target and no default target, skipping`);
+    return emptyDesiredState();
+  }
+
+  const ttl = Number(labels[`${PREFIX}ttl`] ?? DEFAULT_TTL);
+  const providerSpecific = providerHints(labels);
+
+  const records: DnsRecord[] = hostnames.map((hostname) => ({
+    hostname,
+    type: rawType as RecordType,
+    target,
+    ttl: Number.isFinite(ttl) && ttl > 0 ? ttl : DEFAULT_TTL,
+    source: container.Id,
+    ...(providerSpecific ? { providerSpecific } : {}),
+  }));
+  return { records, tunnelRoutes: [] };
+}
+
+function isValidServiceUrl(service: string): boolean {
+  try {
+    return TUNNEL_SERVICE_SCHEMES.includes(new URL(service).protocol);
+  } catch {
+    return false;
+  }
+}
+
+/** Collects dockroute.<provider>.<key> labels (e.g. cloudflare.proxied). */
+function providerHints(labels: Record<string, string>): Record<string, string> | undefined {
+  let hints: Record<string, string> | undefined;
+  for (const [key, value] of Object.entries(labels)) {
+    if (!key.startsWith(PREFIX)) continue;
+    const suffix = key.slice(PREFIX.length);
+    if (KNOWN_KEYS.has(suffix) || !suffix.includes(".")) continue;
+    (hints ??= {})[suffix] = value;
+  }
+  return hints;
+}

--- a/src/core/labels.ts
+++ b/src/core/labels.ts
@@ -60,7 +60,7 @@ function tunnelState(
   if (!isValidServiceUrl(service)) {
     console.warn(
       `[labels] ${name}: invalid dockroute.tunnel.service "${service}" ` +
-        `(expected ${TUNNEL_SERVICE_SCHEMES.map((s) => s + "//").join(", ")}), skipping`,
+        `(expected ${TUNNEL_SERVICE_SCHEMES.map((s) => `${s}//`).join(", ")}), skipping`,
     );
     return emptyDesiredState();
   }
@@ -123,7 +123,8 @@ function providerHints(labels: Record<string, string>): Record<string, string> |
     if (!key.startsWith(PREFIX)) continue;
     const suffix = key.slice(PREFIX.length);
     if (KNOWN_KEYS.has(suffix) || !suffix.includes(".")) continue;
-    (hints ??= {})[suffix] = value;
+    hints ??= {};
+    hints[suffix] = value;
   }
   return hints;
 }

--- a/src/core/reconciler.test.ts
+++ b/src/core/reconciler.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import type { DockerClient } from "../docker/client";
+import type { Provider } from "../providers/provider";
+import { mergeDesired, Reconciler } from "./reconciler";
+import type { ContainerInfo, DesiredState, DnsRecord, TunnelRoute } from "./types";
+
+function container(id: string, labels: Record<string, string>): ContainerInfo {
+  return { Id: id, Names: [`/${id}`], Labels: labels, State: "running" };
+}
+
+function record(hostname: string, over: Partial<DnsRecord> = {}): DnsRecord {
+  return { hostname, type: "A", target: "10.0.0.1", ttl: 300, source: "c1", ...over };
+}
+
+function route(hostname: string, over: Partial<TunnelRoute> = {}): TunnelRoute {
+  return { hostname, service: "http://app:80", source: "c1", ...over };
+}
+
+class FakeProvider implements Provider {
+  readonly name = "fake";
+  synced: DesiredState[] = [];
+  failNext = false;
+
+  async sync(desired: DesiredState): Promise<void> {
+    if (this.failNext) {
+      this.failNext = false;
+      throw new Error("boom");
+    }
+    this.synced.push(desired);
+  }
+}
+
+function fakeDocker(containers: ContainerInfo[]): DockerClient {
+  return { listRunningContainers: async () => containers } as unknown as DockerClient;
+}
+
+describe("mergeDesired", () => {
+  test("aggregates records and tunnel routes across containers", () => {
+    const merged = mergeDesired([
+      { records: [record("a.example.com")], tunnelRoutes: [] },
+      { records: [], tunnelRoutes: [route("t.example.com")] },
+    ]);
+    expect(merged.records).toHaveLength(1);
+    expect(merged.tunnelRoutes).toHaveLength(1);
+  });
+
+  test("dedupes duplicate hostname+type, first container wins", () => {
+    const merged = mergeDesired([
+      { records: [record("a.example.com", { target: "10.0.0.1" })], tunnelRoutes: [] },
+      { records: [record("a.example.com", { target: "10.0.0.2", source: "c2" })], tunnelRoutes: [] },
+    ]);
+    expect(merged.records).toEqual([record("a.example.com", { target: "10.0.0.1" })]);
+  });
+
+  test("same hostname with different types is allowed", () => {
+    const merged = mergeDesired([
+      { records: [record("a.example.com"), record("a.example.com", { type: "AAAA", target: "::1" })], tunnelRoutes: [] },
+    ]);
+    expect(merged.records).toHaveLength(2);
+  });
+
+  test("tunnel route claims the hostname over any record", () => {
+    const merged = mergeDesired([
+      { records: [], tunnelRoutes: [route("a.example.com")] },
+      { records: [record("a.example.com", { source: "c2" })], tunnelRoutes: [] },
+    ]);
+    expect(merged.records).toEqual([]);
+    expect(merged.tunnelRoutes).toHaveLength(1);
+  });
+
+  test("dedupes duplicate tunnel routes, first wins", () => {
+    const merged = mergeDesired([
+      { records: [], tunnelRoutes: [route("a.example.com", { service: "http://one:80" })] },
+      { records: [], tunnelRoutes: [route("a.example.com", { service: "http://two:80", source: "c2" })] },
+    ]);
+    expect(merged.tunnelRoutes).toEqual([route("a.example.com", { service: "http://one:80" })]);
+  });
+});
+
+describe("Reconciler", () => {
+  test("hands the provider the merged desired state from all containers", async () => {
+    const provider = new FakeProvider();
+    const reconciler = new Reconciler(
+      fakeDocker([
+        container("c1", { "dockroute.enabled": "true", "dockroute.hostname": "a.example.com" }),
+        container("c2", {
+          "dockroute.enabled": "true",
+          "dockroute.hostname": "t.example.com",
+          "dockroute.tunnel.service": "http://app:80",
+        }),
+      ]),
+      provider,
+      { defaultTarget: "10.0.0.1" },
+    );
+
+    await reconciler.reconcile();
+
+    expect(provider.synced).toHaveLength(1);
+    expect(provider.synced[0]?.records.map((r) => r.hostname)).toEqual(["a.example.com"]);
+    expect(provider.synced[0]?.tunnelRoutes.map((t) => t.hostname)).toEqual(["t.example.com"]);
+  });
+
+  test("survives a provider error and keeps reconciling", async () => {
+    const provider = new FakeProvider();
+    provider.failNext = true;
+    const reconciler = new Reconciler(fakeDocker([]), provider, {});
+
+    await reconciler.reconcile();
+    await reconciler.reconcile();
+
+    expect(provider.synced).toHaveLength(1);
+  });
+});

--- a/src/core/reconciler.test.ts
+++ b/src/core/reconciler.test.ts
@@ -47,14 +47,23 @@ describe("mergeDesired", () => {
   test("dedupes duplicate hostname+type, first container wins", () => {
     const merged = mergeDesired([
       { records: [record("a.example.com", { target: "10.0.0.1" })], tunnelRoutes: [] },
-      { records: [record("a.example.com", { target: "10.0.0.2", source: "c2" })], tunnelRoutes: [] },
+      {
+        records: [record("a.example.com", { target: "10.0.0.2", source: "c2" })],
+        tunnelRoutes: [],
+      },
     ]);
     expect(merged.records).toEqual([record("a.example.com", { target: "10.0.0.1" })]);
   });
 
   test("same hostname with different types is allowed", () => {
     const merged = mergeDesired([
-      { records: [record("a.example.com"), record("a.example.com", { type: "AAAA", target: "::1" })], tunnelRoutes: [] },
+      {
+        records: [
+          record("a.example.com"),
+          record("a.example.com", { type: "AAAA", target: "::1" }),
+        ],
+        tunnelRoutes: [],
+      },
     ]);
     expect(merged.records).toHaveLength(2);
   });
@@ -71,7 +80,10 @@ describe("mergeDesired", () => {
   test("dedupes duplicate tunnel routes, first wins", () => {
     const merged = mergeDesired([
       { records: [], tunnelRoutes: [route("a.example.com", { service: "http://one:80" })] },
-      { records: [], tunnelRoutes: [route("a.example.com", { service: "http://two:80", source: "c2" })] },
+      {
+        records: [],
+        tunnelRoutes: [route("a.example.com", { service: "http://two:80", source: "c2" })],
+      },
     ]);
     expect(merged.tunnelRoutes).toEqual([route("a.example.com", { service: "http://one:80" })]);
   });

--- a/src/core/reconciler.ts
+++ b/src/core/reconciler.ts
@@ -1,0 +1,82 @@
+import type { DockerClient } from "../docker/client";
+import type { Provider } from "../providers/provider";
+import { desiredFromContainer, type ParseOptions } from "./labels";
+import type { DesiredState, DnsRecord, TunnelRoute } from "./types";
+
+/**
+ * Recomputes the full desired state from all running containers and hands it
+ * to the provider. Serialized: if a reconcile is already running, the request
+ * is coalesced into one follow-up run.
+ */
+export class Reconciler {
+  private running = false;
+  private pending = false;
+
+  constructor(
+    private docker: DockerClient,
+    private provider: Provider,
+    private parseOpts: ParseOptions,
+  ) {}
+
+  async reconcile(): Promise<void> {
+    if (this.running) {
+      this.pending = true;
+      return;
+    }
+    this.running = true;
+    try {
+      do {
+        this.pending = false;
+        const containers = await this.docker.listRunningContainers();
+        const perContainer = containers.map((c) => desiredFromContainer(c, this.parseOpts));
+        await this.provider.sync(mergeDesired(perContainer));
+      } while (this.pending);
+    } catch (err) {
+      console.error("[reconciler] reconcile failed:", err);
+    } finally {
+      this.running = false;
+    }
+  }
+}
+
+/**
+ * Merges per-container states and dedupes: a hostname may be claimed once per
+ * record type, and once across all tunnel routes (first container wins).
+ * A hostname claimed by a tunnel route also cannot be claimed as a record.
+ */
+export function mergeDesired(states: DesiredState[]): DesiredState {
+  const records: DnsRecord[] = [];
+  const tunnelRoutes: TunnelRoute[] = [];
+  const seen = new Set<string>();
+
+  for (const state of states) {
+    for (const route of state.tunnelRoutes) {
+      if (claim(seen, `tunnel:${route.hostname}`, route.source)) tunnelRoutes.push(route);
+    }
+  }
+  for (const state of states) {
+    for (const record of state.records) {
+      if (seen.has(`tunnel:${record.hostname}`)) {
+        console.warn(
+          `[reconciler] duplicate hostname ${record.hostname}: already published via tunnel, ` +
+            `skipping ${record.type} record from ${record.source.slice(0, 12)}`,
+        );
+        continue;
+      }
+      if (claim(seen, `${record.type}:${record.hostname}`, record.source)) records.push(record);
+    }
+  }
+  return { records, tunnelRoutes };
+}
+
+function claim(seen: Set<string>, key: string, source: string): boolean {
+  if (seen.has(key)) {
+    console.warn(
+      `[reconciler] duplicate desired entry ${key}: first container wins, ` +
+        `skipping entry from ${source.slice(0, 12)}`,
+    );
+    return false;
+  }
+  seen.add(key);
+  return true;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,35 @@
+export type RecordType = "A" | "AAAA" | "CNAME";
+
+export interface DnsRecord {
+  hostname: string;
+  type: RecordType;
+  target: string;
+  ttl: number;
+  /** Container id that produced this record (ownership/debugging). */
+  source: string;
+  /** Opaque provider hints from dockroute.<provider>.* labels (e.g. cloudflare.proxied). */
+  providerSpecific?: Record<string, string>;
+}
+
+/** A hostname published through a tunnel to an origin service inside the stack. */
+export interface TunnelRoute {
+  hostname: string;
+  /** Origin service URL, e.g. "http://whoami:8080". */
+  service: string;
+  /** Container id that produced this route. */
+  source: string;
+}
+
+/** The full desired state assembled from all running containers. */
+export interface DesiredState {
+  records: DnsRecord[];
+  tunnelRoutes: TunnelRoute[];
+}
+
+/** The subset of the Docker container payload DockRoute cares about. */
+export interface ContainerInfo {
+  Id: string;
+  Names: string[];
+  Labels: Record<string, string>;
+  State: string;
+}

--- a/src/docker/client.ts
+++ b/src/docker/client.ts
@@ -1,0 +1,40 @@
+import type { ContainerInfo } from "../core/types";
+
+/**
+ * Minimal Docker Engine API client over the unix socket.
+ * Bun's fetch supports unix sockets natively via the `unix` option.
+ */
+export class DockerClient {
+  constructor(private sockPath: string) {}
+
+  private fetch(path: string): Promise<Response> {
+    return fetch(`http://docker${path}`, { unix: this.sockPath });
+  }
+
+  async listRunningContainers(): Promise<ContainerInfo[]> {
+    const res = await this.fetch("/containers/json");
+    if (!res.ok) throw new Error(`Docker API ${res.status}: ${await res.text()}`);
+    return (await res.json()) as ContainerInfo[];
+  }
+
+  /**
+   * Streams container lifecycle events. Yields once per relevant event;
+   * callers only use it as a reconcile trigger, so the payload is discarded.
+   */
+  async *containerEvents(signal?: AbortSignal): AsyncGenerator<void> {
+    const filters = JSON.stringify({
+      type: ["container"],
+      event: ["start", "die", "stop", "destroy"],
+    });
+    const res = await fetch(
+      `http://docker/events?filters=${encodeURIComponent(filters)}`,
+      { unix: this.sockPath, signal },
+    );
+    if (!res.ok || !res.body) {
+      throw new Error(`Docker events API ${res.status}`);
+    }
+    for await (const _chunk of res.body) {
+      yield;
+    }
+  }
+}

--- a/src/docker/client.ts
+++ b/src/docker/client.ts
@@ -26,10 +26,10 @@ export class DockerClient {
       type: ["container"],
       event: ["start", "die", "stop", "destroy"],
     });
-    const res = await fetch(
-      `http://docker/events?filters=${encodeURIComponent(filters)}`,
-      { unix: this.sockPath, signal },
-    );
+    const res = await fetch(`http://docker/events?filters=${encodeURIComponent(filters)}`, {
+      unix: this.sockPath,
+      signal,
+    });
     if (!res.ok || !res.body) {
       throw new Error(`Docker events API ${res.status}`);
     }

--- a/src/docker/watcher.ts
+++ b/src/docker/watcher.ts
@@ -1,0 +1,48 @@
+import type { Reconciler } from "../core/reconciler";
+import type { DockerClient } from "./client";
+
+const EVENT_STREAM_RETRY_MS = 5_000;
+
+/**
+ * Drives the reconcile loop: once at startup, on every container
+ * lifecycle event, and on a periodic resync as a safety net.
+ */
+export class Watcher {
+  private timer?: ReturnType<typeof setInterval>;
+  private abort = new AbortController();
+
+  constructor(
+    private docker: DockerClient,
+    private reconciler: Reconciler,
+    private resyncSeconds: number,
+  ) {}
+
+  async start(): Promise<void> {
+    await this.reconciler.reconcile();
+
+    this.timer = setInterval(() => {
+      void this.reconciler.reconcile();
+    }, this.resyncSeconds * 1000);
+
+    void this.watchEvents();
+  }
+
+  stop(): void {
+    this.abort.abort();
+    clearInterval(this.timer);
+  }
+
+  private async watchEvents(): Promise<void> {
+    while (!this.abort.signal.aborted) {
+      try {
+        for await (const _ of this.docker.containerEvents(this.abort.signal)) {
+          await this.reconciler.reconcile();
+        }
+      } catch (err) {
+        if (this.abort.signal.aborted) return;
+        console.error(`[watcher] event stream lost, retrying in ${EVENT_STREAM_RETRY_MS}ms:`, err);
+        await Bun.sleep(EVENT_STREAM_RETRY_MS);
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,26 @@
+import { loadConfig } from "./config";
+import { Reconciler } from "./core/reconciler";
+import { DockerClient } from "./docker/client";
+import { Watcher } from "./docker/watcher";
+import { createProvider } from "./providers/provider";
+import "./providers/log";
+import "./providers/cloudflare/cloudflare";
+
+const config = loadConfig();
+console.log(`dockroute starting (provider=${config.provider}, sock=${config.dockerSock})`);
+
+const docker = new DockerClient(config.dockerSock);
+const provider = createProvider(config.provider, config);
+const reconciler = new Reconciler(docker, provider, { defaultTarget: config.defaultTarget });
+
+const watcher = new Watcher(docker, reconciler, config.resyncSeconds);
+
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, () => {
+    console.log(`received ${sig}, shutting down`);
+    watcher.stop();
+    process.exit(0);
+  });
+}
+
+await watcher.start();

--- a/src/providers/cloudflare/api.test.ts
+++ b/src/providers/cloudflare/api.test.ts
@@ -7,7 +7,9 @@ afterEach(() => {
   globalThis.fetch = realFetch;
 });
 
-function stubFetch(handler: (url: string, init?: RequestInit) => { status?: number; body: unknown }) {
+function stubFetch(
+  handler: (url: string, init?: RequestInit) => { status?: number; body: unknown },
+) {
   const calls: string[] = [];
   globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
     const u = String(url);
@@ -53,7 +55,11 @@ describe("CloudflareFetchApi", () => {
   test("surfaces Cloudflare error messages", async () => {
     stubFetch(() => ({
       status: 403,
-      body: { success: false, errors: [{ code: 9109, message: "Invalid access token" }], result: null },
+      body: {
+        success: false,
+        errors: [{ code: 9109, message: "Invalid access token" }],
+        result: null,
+      },
     }));
 
     expect(new CloudflareFetchApi("bad").listZones()).rejects.toThrow(/9109: Invalid access token/);

--- a/src/providers/cloudflare/api.test.ts
+++ b/src/providers/cloudflare/api.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { CloudflareFetchApi } from "./api";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function stubFetch(handler: (url: string, init?: RequestInit) => { status?: number; body: unknown }) {
+  const calls: string[] = [];
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    calls.push(u);
+    const { status = 200, body } = handler(u, init);
+    return new Response(JSON.stringify(body), { status });
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("CloudflareFetchApi", () => {
+  test("consumes every page when listing", async () => {
+    const calls = stubFetch((url) => {
+      const page = Number(new URL(url).searchParams.get("page"));
+      return {
+        body: {
+          success: true,
+          errors: [],
+          result: [{ id: `z${page}`, name: `zone${page}.com` }],
+          result_info: { page, total_pages: 3 },
+        },
+      };
+    });
+
+    const zones = await new CloudflareFetchApi("token").listZones();
+
+    expect(zones.map((z) => z.id)).toEqual(["z1", "z2", "z3"]);
+    expect(calls).toHaveLength(3);
+  });
+
+  test("sends the bearer token", async () => {
+    let auth: string | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      auth = new Headers(init?.headers).get("Authorization") ?? undefined;
+      return new Response(JSON.stringify({ success: true, errors: [], result: [] }));
+    }) as typeof fetch;
+
+    await new CloudflareFetchApi("secret-token").listZones();
+
+    expect(auth).toBe("Bearer secret-token");
+  });
+
+  test("surfaces Cloudflare error messages", async () => {
+    stubFetch(() => ({
+      status: 403,
+      body: { success: false, errors: [{ code: 9109, message: "Invalid access token" }], result: null },
+    }));
+
+    expect(new CloudflareFetchApi("bad").listZones()).rejects.toThrow(/9109: Invalid access token/);
+  });
+
+  test("unwraps a null tunnel config", async () => {
+    stubFetch(() => ({ body: { success: true, errors: [], result: { config: null } } }));
+
+    const config = await new CloudflareFetchApi("token").getTunnelConfig("acc", "tun");
+
+    expect(config).toBeNull();
+  });
+});

--- a/src/providers/cloudflare/api.ts
+++ b/src/providers/cloudflare/api.ts
@@ -1,0 +1,128 @@
+/**
+ * Thin Cloudflare v4 API client. All Cloudflare wire types live here and in
+ * the sibling provider files — they must never leak into src/core/ (ACL).
+ * Exported as an interface so tests inject an in-memory fake.
+ */
+
+const BASE_URL = "https://api.cloudflare.com/client/v4";
+const PER_PAGE = 100;
+
+export interface CfZone {
+  id: string;
+  name: string;
+}
+
+export interface CfDnsRecord {
+  id: string;
+  type: string;
+  name: string;
+  content: string;
+  ttl: number;
+  proxied?: boolean;
+}
+
+export type CfDnsRecordInput = Omit<CfDnsRecord, "id">;
+
+export interface CfIngressRule {
+  hostname?: string;
+  service: string;
+  path?: string;
+  /** Cloudflare allows extra per-rule settings; preserved verbatim. */
+  [key: string]: unknown;
+}
+
+/** Remotely-managed tunnel configuration. Unknown fields are preserved on PUT. */
+export interface CfTunnelConfig {
+  ingress?: CfIngressRule[];
+  [key: string]: unknown;
+}
+
+export interface CloudflareApi {
+  listZones(): Promise<CfZone[]>;
+  listDnsRecords(zoneId: string): Promise<CfDnsRecord[]>;
+  createDnsRecord(zoneId: string, record: CfDnsRecordInput): Promise<void>;
+  updateDnsRecord(zoneId: string, recordId: string, record: CfDnsRecordInput): Promise<void>;
+  deleteDnsRecord(zoneId: string, recordId: string): Promise<void>;
+  getTunnelConfig(accountId: string, tunnelId: string): Promise<CfTunnelConfig | null>;
+  putTunnelConfig(accountId: string, tunnelId: string, config: CfTunnelConfig): Promise<void>;
+}
+
+interface CfResponse<T> {
+  success: boolean;
+  errors: { code: number; message: string }[];
+  result: T;
+  result_info?: { page: number; total_pages: number };
+}
+
+export class CloudflareFetchApi implements CloudflareApi {
+  constructor(private apiToken: string) {}
+
+  async listZones(): Promise<CfZone[]> {
+    return this.paginate<CfZone>("/zones");
+  }
+
+  async listDnsRecords(zoneId: string): Promise<CfDnsRecord[]> {
+    return this.paginate<CfDnsRecord>(`/zones/${zoneId}/dns_records`);
+  }
+
+  async createDnsRecord(zoneId: string, record: CfDnsRecordInput): Promise<void> {
+    await this.request(`/zones/${zoneId}/dns_records`, "POST", record);
+  }
+
+  async updateDnsRecord(zoneId: string, recordId: string, record: CfDnsRecordInput): Promise<void> {
+    await this.request(`/zones/${zoneId}/dns_records/${recordId}`, "PUT", record);
+  }
+
+  async deleteDnsRecord(zoneId: string, recordId: string): Promise<void> {
+    await this.request(`/zones/${zoneId}/dns_records/${recordId}`, "DELETE");
+  }
+
+  async getTunnelConfig(accountId: string, tunnelId: string): Promise<CfTunnelConfig | null> {
+    const result = await this.request<{ config: CfTunnelConfig | null }>(
+      `/accounts/${accountId}/cfd_tunnel/${tunnelId}/configurations`,
+      "GET",
+    );
+    return result.config ?? null;
+  }
+
+  async putTunnelConfig(accountId: string, tunnelId: string, config: CfTunnelConfig): Promise<void> {
+    await this.request(
+      `/accounts/${accountId}/cfd_tunnel/${tunnelId}/configurations`,
+      "PUT",
+      { config },
+    );
+  }
+
+  private async paginate<T>(path: string): Promise<T[]> {
+    const items: T[] = [];
+    for (let page = 1, totalPages = 1; page <= totalPages; page++) {
+      const res = await this.rawRequest<T[]>(`${path}?page=${page}&per_page=${PER_PAGE}`, "GET");
+      items.push(...res.result);
+      totalPages = res.result_info?.total_pages ?? 1;
+    }
+    return items;
+  }
+
+  private async request<T>(path: string, method: string, body?: unknown): Promise<T> {
+    return (await this.rawRequest<T>(path, method, body)).result;
+  }
+
+  private async rawRequest<T>(path: string, method: string, body?: unknown): Promise<CfResponse<T>> {
+    const res = await fetch(`${BASE_URL}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.apiToken}`,
+        "Content-Type": "application/json",
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+
+    const payload = (await res.json().catch(() => null)) as CfResponse<T> | null;
+    if (!res.ok || !payload?.success) {
+      const details =
+        payload?.errors?.map((e) => `${e.code}: ${e.message}`).join("; ") ?? `HTTP ${res.status}`;
+      throw new Error(`Cloudflare API ${method} ${path} failed — ${details}`);
+    }
+    return payload;
+  }
+}

--- a/src/providers/cloudflare/api.ts
+++ b/src/providers/cloudflare/api.ts
@@ -85,12 +85,14 @@ export class CloudflareFetchApi implements CloudflareApi {
     return result.config ?? null;
   }
 
-  async putTunnelConfig(accountId: string, tunnelId: string, config: CfTunnelConfig): Promise<void> {
-    await this.request(
-      `/accounts/${accountId}/cfd_tunnel/${tunnelId}/configurations`,
-      "PUT",
-      { config },
-    );
+  async putTunnelConfig(
+    accountId: string,
+    tunnelId: string,
+    config: CfTunnelConfig,
+  ): Promise<void> {
+    await this.request(`/accounts/${accountId}/cfd_tunnel/${tunnelId}/configurations`, "PUT", {
+      config,
+    });
   }
 
   private async paginate<T>(path: string): Promise<T[]> {
@@ -107,7 +109,11 @@ export class CloudflareFetchApi implements CloudflareApi {
     return (await this.rawRequest<T>(path, method, body)).result;
   }
 
-  private async rawRequest<T>(path: string, method: string, body?: unknown): Promise<CfResponse<T>> {
+  private async rawRequest<T>(
+    path: string,
+    method: string,
+    body?: unknown,
+  ): Promise<CfResponse<T>> {
     const res = await fetch(`${BASE_URL}${path}`, {
       method,
       headers: {

--- a/src/providers/cloudflare/cloudflare.test.ts
+++ b/src/providers/cloudflare/cloudflare.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, test } from "bun:test";
+import { loadConfig, type Config } from "../../config";
+import type { DesiredState, DnsRecord, TunnelRoute } from "../../core/types";
+import { formatOwnershipContent } from "../registry/ownership";
+import type {
+  CfDnsRecord,
+  CfDnsRecordInput,
+  CfIngressRule,
+  CfTunnelConfig,
+  CfZone,
+  CloudflareApi,
+} from "./api";
+import { CloudflareProvider } from "./cloudflare";
+
+const TUNNEL_ID = "tun-1";
+const TUNNEL_DOMAIN = `${TUNNEL_ID}.cfargotunnel.com`;
+const CATCH_ALL: CfIngressRule = { service: "http_status:404" };
+
+class FakeCloudflareApi implements CloudflareApi {
+  zones: CfZone[] = [{ id: "z1", name: "example.com" }];
+  records = new Map<string, CfDnsRecord[]>([["z1", []]]);
+  tunnelConfig: CfTunnelConfig | null = null;
+  tunnelPuts: CfTunnelConfig[] = [];
+  private nextId = 1;
+
+  seed(zoneId: string, record: Omit<CfDnsRecord, "id">): CfDnsRecord {
+    const stored = { ...record, id: `r${this.nextId++}` };
+    this.records.get(zoneId)!.push(stored);
+    return stored;
+  }
+
+  async listZones(): Promise<CfZone[]> {
+    return this.zones;
+  }
+
+  async listDnsRecords(zoneId: string): Promise<CfDnsRecord[]> {
+    return [...(this.records.get(zoneId) ?? [])];
+  }
+
+  async createDnsRecord(zoneId: string, record: CfDnsRecordInput): Promise<void> {
+    this.seed(zoneId, record);
+  }
+
+  async updateDnsRecord(zoneId: string, recordId: string, record: CfDnsRecordInput): Promise<void> {
+    const list = this.records.get(zoneId) ?? [];
+    const index = list.findIndex((r) => r.id === recordId);
+    if (index === -1) throw new Error(`no such record ${recordId}`);
+    list[index] = { ...record, id: recordId };
+  }
+
+  async deleteDnsRecord(zoneId: string, recordId: string): Promise<void> {
+    const list = this.records.get(zoneId) ?? [];
+    this.records.set(zoneId, list.filter((r) => r.id !== recordId));
+  }
+
+  async getTunnelConfig(): Promise<CfTunnelConfig | null> {
+    return this.tunnelConfig;
+  }
+
+  async putTunnelConfig(_a: string, _t: string, config: CfTunnelConfig): Promise<void> {
+    this.tunnelConfig = config;
+    this.tunnelPuts.push(config);
+  }
+
+  find(zoneId: string, type: string, name: string): CfDnsRecord | undefined {
+    return (this.records.get(zoneId) ?? []).find((r) => r.type === type && r.name === name);
+  }
+}
+
+function makeConfig(env: Record<string, string> = {}): Config {
+  return loadConfig({
+    DOCKROUTE_PROVIDER: "cloudflare",
+    CLOUDFLARE_API_TOKEN: "token",
+    DOCKROUTE_OWNER_ID: "home-lab",
+    ...env,
+  });
+}
+
+const tunnelEnv = { CLOUDFLARE_ACCOUNT_ID: "acc-1", CLOUDFLARE_TUNNEL_ID: TUNNEL_ID };
+
+function record(hostname: string, over: Partial<DnsRecord> = {}): DnsRecord {
+  return { hostname, type: "A", target: "10.0.0.1", ttl: 300, source: "c1", ...over };
+}
+
+function route(hostname: string, over: Partial<TunnelRoute> = {}): TunnelRoute {
+  return { hostname, service: "http://app:80", source: "c1", ...over };
+}
+
+function desired(over: Partial<DesiredState> = {}): DesiredState {
+  return { records: [], tunnelRoutes: [], ...over };
+}
+
+const OWNED_TXT = formatOwnershipContent({ owner: "home-lab" });
+
+function seedOwned(api: FakeCloudflareApi, hostname: string, over: Partial<CfDnsRecord> = {}) {
+  const type = over.type ?? "A";
+  api.seed("z1", { type, name: hostname, content: over.content ?? "10.0.0.1", ttl: over.ttl ?? 300, ...over });
+  api.seed("z1", {
+    type: "TXT",
+    name: `_dockroute-${type.toLowerCase()}.${hostname}`,
+    content: OWNED_TXT,
+    ttl: 300,
+  });
+}
+
+describe("CloudflareProvider — DNS", () => {
+  test("creates the record and its ownership TXT", async () => {
+    const api = new FakeCloudflareApi();
+    const provider = new CloudflareProvider(api, makeConfig());
+
+    await provider.sync(desired({ records: [record("a.example.com")] }));
+
+    expect(api.find("z1", "A", "a.example.com")).toMatchObject({
+      content: "10.0.0.1",
+      ttl: 300,
+      proxied: false,
+    });
+    expect(api.find("z1", "TXT", "_dockroute-a.a.example.com")?.content).toBe(
+      formatOwnershipContent({ owner: "home-lab", resource: "container/c1" }),
+    );
+  });
+
+  test("routes each hostname to the longest matching zone", async () => {
+    const api = new FakeCloudflareApi();
+    api.zones = [
+      { id: "z1", name: "example.com" },
+      { id: "z2", name: "sub.example.com" },
+    ];
+    api.records.set("z2", []);
+    const provider = new CloudflareProvider(api, makeConfig());
+
+    await provider.sync(desired({ records: [record("a.sub.example.com"), record("b.example.com")] }));
+
+    expect(api.find("z2", "A", "a.sub.example.com")).toBeDefined();
+    expect(api.find("z1", "A", "a.sub.example.com")).toBeUndefined();
+    expect(api.find("z1", "A", "b.example.com")).toBeDefined();
+  });
+
+  test("skips hostnames without a matching zone", async () => {
+    const api = new FakeCloudflareApi();
+    const provider = new CloudflareProvider(api, makeConfig());
+
+    await provider.sync(desired({ records: [record("a.other.org")] }));
+
+    expect(api.records.get("z1")).toEqual([]);
+  });
+
+  test("respects the domain filter", async () => {
+    const api = new FakeCloudflareApi();
+    const provider = new CloudflareProvider(api, makeConfig({ DOCKROUTE_DOMAIN_FILTER: "other.org" }));
+
+    await provider.sync(desired({ records: [record("a.example.com")] }));
+
+    expect(api.records.get("z1")).toEqual([]);
+  });
+
+  test("never touches an existing record without our ownership TXT", async () => {
+    const api = new FakeCloudflareApi();
+    const manual = api.seed("z1", { type: "A", name: "a.example.com", content: "1.2.3.4", ttl: 60 });
+    const provider = new CloudflareProvider(api, makeConfig());
+
+    await provider.sync(desired({ records: [record("a.example.com")] }));
+
+    expect(api.find("z1", "A", "a.example.com")).toEqual(manual);
+    expect(api.find("z1", "TXT", "_dockroute-a.a.example.com")).toBeUndefined();
+  });
+
+  test("updates an owned record whose target changed", async () => {
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "a.example.com", { content: "10.0.0.9" });
+    const provider = new CloudflareProvider(api, makeConfig());
+
+    await provider.sync(desired({ records: [record("a.example.com")] }));
+
+    expect(api.find("z1", "A", "a.example.com")?.content).toBe("10.0.0.1");
+  });
+
+  test("sync deletes owned orphans together with their TXT", async () => {
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "gone.example.com");
+    const provider = new CloudflareProvider(api, makeConfig());
+
+    await provider.sync(desired());
+
+    expect(api.records.get("z1")).toEqual([]);
+  });
+
+  test("upsert-only keeps owned orphans", async () => {
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "gone.example.com");
+    const provider = new CloudflareProvider(api, makeConfig({ DOCKROUTE_POLICY: "upsert-only" }));
+
+    await provider.sync(desired());
+
+    expect(api.records.get("z1")).toHaveLength(2);
+  });
+
+  test("proxied records do not cause perpetual TTL updates", async () => {
+    const api = new FakeCloudflareApi();
+    // Cloudflare stores proxied records with ttl=1 regardless of the label.
+    seedOwned(api, "a.example.com", { proxied: true, ttl: 1 });
+    let updates = 0;
+    const originalUpdate = api.updateDnsRecord.bind(api);
+    api.updateDnsRecord = async (...args) => {
+      updates++;
+      return originalUpdate(...args);
+    };
+    const provider = new CloudflareProvider(api, makeConfig());
+
+    await provider.sync(
+      desired({
+        records: [record("a.example.com", { providerSpecific: { "cloudflare.proxied": "true" } })],
+      }),
+    );
+
+    expect(updates).toBe(0);
+  });
+});
+
+describe("CloudflareProvider — tunnel", () => {
+  test("creates a proxied CNAME to the tunnel domain and adds the ingress route", async () => {
+    const api = new FakeCloudflareApi();
+    const provider = new CloudflareProvider(api, makeConfig(tunnelEnv));
+
+    await provider.sync(desired({ tunnelRoutes: [route("t.example.com")] }));
+
+    expect(api.find("z1", "CNAME", "t.example.com")).toMatchObject({
+      content: TUNNEL_DOMAIN,
+      proxied: true,
+    });
+    expect(api.find("z1", "TXT", "_dockroute-cname.t.example.com")).toBeDefined();
+    expect(api.tunnelConfig?.ingress).toEqual([
+      { hostname: "t.example.com", service: "http://app:80" },
+      CATCH_ALL,
+    ]);
+  });
+
+  test("warns and skips tunnel routes when tunnel config is missing", async () => {
+    const api = new FakeCloudflareApi();
+    const provider = new CloudflareProvider(api, makeConfig());
+
+    await provider.sync(desired({ tunnelRoutes: [route("t.example.com")] }));
+
+    expect(api.find("z1", "CNAME", "t.example.com")).toBeUndefined();
+    expect(api.tunnelPuts).toEqual([]);
+  });
+
+  test("preserves unmanaged ingress rules and other config fields", async () => {
+    const api = new FakeCloudflareApi();
+    api.tunnelConfig = {
+      ingress: [{ hostname: "keep.example.com", service: "http://keep:80" }, CATCH_ALL],
+      "warp-routing": { enabled: true },
+    };
+    const provider = new CloudflareProvider(api, makeConfig(tunnelEnv));
+
+    await provider.sync(desired({ tunnelRoutes: [route("t.example.com")] }));
+
+    expect(api.tunnelConfig.ingress).toEqual([
+      { hostname: "keep.example.com", service: "http://keep:80" },
+      { hostname: "t.example.com", service: "http://app:80" },
+      CATCH_ALL,
+    ]);
+    expect(api.tunnelConfig["warp-routing"]).toEqual({ enabled: true });
+  });
+
+  test("does not PUT when the ingress is already correct", async () => {
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "t.example.com", { type: "CNAME", content: TUNNEL_DOMAIN, proxied: true, ttl: 1 });
+    api.tunnelConfig = {
+      ingress: [{ hostname: "t.example.com", service: "http://app:80" }, CATCH_ALL],
+    };
+    const provider = new CloudflareProvider(api, makeConfig(tunnelEnv));
+
+    await provider.sync(desired({ tunnelRoutes: [route("t.example.com")] }));
+
+    expect(api.tunnelPuts).toEqual([]);
+  });
+
+  test("sync removes an orphaned managed route and its CNAME", async () => {
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "gone.example.com", { type: "CNAME", content: TUNNEL_DOMAIN, proxied: true, ttl: 1 });
+    api.tunnelConfig = {
+      ingress: [{ hostname: "gone.example.com", service: "http://gone:80" }, CATCH_ALL],
+    };
+    const provider = new CloudflareProvider(api, makeConfig(tunnelEnv));
+
+    await provider.sync(desired());
+
+    expect(api.records.get("z1")).toEqual([]);
+    expect(api.tunnelConfig?.ingress).toEqual([CATCH_ALL]);
+  });
+
+  test("an ingress rule owned by nobody blocks our route (conflict)", async () => {
+    const api = new FakeCloudflareApi();
+    api.tunnelConfig = {
+      ingress: [{ hostname: "t.example.com", service: "http://theirs:80" }, CATCH_ALL],
+    };
+    const provider = new CloudflareProvider(api, makeConfig(tunnelEnv));
+
+    await provider.sync(desired({ tunnelRoutes: [route("t.example.com")] }));
+
+    expect(api.tunnelConfig.ingress?.[0]?.service).toBe("http://theirs:80");
+    expect(api.tunnelPuts).toEqual([]);
+  });
+});

--- a/src/providers/cloudflare/cloudflare.test.ts
+++ b/src/providers/cloudflare/cloudflare.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { loadConfig, type Config } from "../../config";
+import { type Config, loadConfig } from "../../config";
 import type { DesiredState, DnsRecord, TunnelRoute } from "../../core/types";
 import { formatOwnershipContent } from "../registry/ownership";
 import type {
@@ -50,7 +50,10 @@ class FakeCloudflareApi implements CloudflareApi {
 
   async deleteDnsRecord(zoneId: string, recordId: string): Promise<void> {
     const list = this.records.get(zoneId) ?? [];
-    this.records.set(zoneId, list.filter((r) => r.id !== recordId));
+    this.records.set(
+      zoneId,
+      list.filter((r) => r.id !== recordId),
+    );
   }
 
   async getTunnelConfig(): Promise<CfTunnelConfig | null> {
@@ -94,7 +97,13 @@ const OWNED_TXT = formatOwnershipContent({ owner: "home-lab" });
 
 function seedOwned(api: FakeCloudflareApi, hostname: string, over: Partial<CfDnsRecord> = {}) {
   const type = over.type ?? "A";
-  api.seed("z1", { type, name: hostname, content: over.content ?? "10.0.0.1", ttl: over.ttl ?? 300, ...over });
+  api.seed("z1", {
+    type,
+    name: hostname,
+    content: over.content ?? "10.0.0.1",
+    ttl: over.ttl ?? 300,
+    ...over,
+  });
   api.seed("z1", {
     type: "TXT",
     name: `_dockroute-${type.toLowerCase()}.${hostname}`,
@@ -129,7 +138,9 @@ describe("CloudflareProvider — DNS", () => {
     api.records.set("z2", []);
     const provider = new CloudflareProvider(api, makeConfig());
 
-    await provider.sync(desired({ records: [record("a.sub.example.com"), record("b.example.com")] }));
+    await provider.sync(
+      desired({ records: [record("a.sub.example.com"), record("b.example.com")] }),
+    );
 
     expect(api.find("z2", "A", "a.sub.example.com")).toBeDefined();
     expect(api.find("z1", "A", "a.sub.example.com")).toBeUndefined();
@@ -147,7 +158,10 @@ describe("CloudflareProvider — DNS", () => {
 
   test("respects the domain filter", async () => {
     const api = new FakeCloudflareApi();
-    const provider = new CloudflareProvider(api, makeConfig({ DOCKROUTE_DOMAIN_FILTER: "other.org" }));
+    const provider = new CloudflareProvider(
+      api,
+      makeConfig({ DOCKROUTE_DOMAIN_FILTER: "other.org" }),
+    );
 
     await provider.sync(desired({ records: [record("a.example.com")] }));
 
@@ -156,7 +170,12 @@ describe("CloudflareProvider — DNS", () => {
 
   test("never touches an existing record without our ownership TXT", async () => {
     const api = new FakeCloudflareApi();
-    const manual = api.seed("z1", { type: "A", name: "a.example.com", content: "1.2.3.4", ttl: 60 });
+    const manual = api.seed("z1", {
+      type: "A",
+      name: "a.example.com",
+      content: "1.2.3.4",
+      ttl: 60,
+    });
     const provider = new CloudflareProvider(api, makeConfig());
 
     await provider.sync(desired({ records: [record("a.example.com")] }));
@@ -265,7 +284,12 @@ describe("CloudflareProvider — tunnel", () => {
 
   test("does not PUT when the ingress is already correct", async () => {
     const api = new FakeCloudflareApi();
-    seedOwned(api, "t.example.com", { type: "CNAME", content: TUNNEL_DOMAIN, proxied: true, ttl: 1 });
+    seedOwned(api, "t.example.com", {
+      type: "CNAME",
+      content: TUNNEL_DOMAIN,
+      proxied: true,
+      ttl: 1,
+    });
     api.tunnelConfig = {
       ingress: [{ hostname: "t.example.com", service: "http://app:80" }, CATCH_ALL],
     };
@@ -278,7 +302,12 @@ describe("CloudflareProvider — tunnel", () => {
 
   test("sync removes an orphaned managed route and its CNAME", async () => {
     const api = new FakeCloudflareApi();
-    seedOwned(api, "gone.example.com", { type: "CNAME", content: TUNNEL_DOMAIN, proxied: true, ttl: 1 });
+    seedOwned(api, "gone.example.com", {
+      type: "CNAME",
+      content: TUNNEL_DOMAIN,
+      proxied: true,
+      ttl: 1,
+    });
     api.tunnelConfig = {
       ingress: [{ hostname: "gone.example.com", service: "http://gone:80" }, CATCH_ALL],
     };

--- a/src/providers/cloudflare/cloudflare.ts
+++ b/src/providers/cloudflare/cloudflare.ts
@@ -1,0 +1,296 @@
+import type { Config } from "../../config";
+import type { DesiredState, DnsRecord, TunnelRoute } from "../../core/types";
+import { registerProvider, type Provider } from "../provider";
+import { planChanges, type Plan, type RegistryRecord } from "../registry/planner";
+import { parseOwnershipContent, parseTxtName } from "../registry/ownership";
+import {
+  CloudflareFetchApi,
+  type CfDnsRecord,
+  type CfDnsRecordInput,
+  type CfZone,
+  type CloudflareApi,
+} from "./api";
+import { mergeIngress } from "./tunnel";
+
+const PROXIED_HINT = "cloudflare.proxied";
+/** Cloudflare forces TTL 1 ("auto") on proxied records; normalize both sides
+ * before diffing or every reconcile issues a no-op update forever. */
+const PROXIED_TTL = 1;
+
+interface ActualEntry {
+  registry: RegistryRecord;
+  id: string;
+}
+
+export class CloudflareProvider implements Provider {
+  readonly name = "cloudflare";
+
+  constructor(
+    private api: CloudflareApi,
+    private config: Config,
+  ) {}
+
+  async sync(desired: DesiredState): Promise<void> {
+    const tunnelDomain = this.tunnelDomain(desired.tunnelRoutes);
+    const tunnelRoutes = tunnelDomain ? desired.tunnelRoutes : [];
+
+    const desiredRegistry = [
+      ...desired.records.map((r) => toRegistry(r)),
+      ...tunnelRoutes.map((t) => tunnelCname(t, tunnelDomain!)),
+    ];
+
+    const zones = await this.matchingZones();
+    const byZone = groupByZone(desiredRegistry, zones);
+    for (const record of desiredRegistry) {
+      if (!byZone.dropped.has(record.hostname)) continue;
+      console.warn(`[cloudflare] ${record.hostname}: no matching zone, skipping`);
+    }
+
+    const managedTunnelHostnames = new Set<string>();
+    const conflictedHostnames = new Set<string>();
+
+    for (const zone of zones) {
+      try {
+        const actual = await this.fetchActual(zone.id);
+        const plan = planChanges({
+          desired: byZone.perZone.get(zone.id) ?? [],
+          actual: actual.map((e) => e.registry),
+          ownerId: this.config.ownerId,
+          txtPrefix: this.config.txtPrefix,
+          policy: this.config.policy,
+        });
+        for (const c of plan.conflicts) {
+          console.warn(`[cloudflare] conflict on ${c.type} ${c.hostname}: ${c.reason} — skipping`);
+          conflictedHostnames.add(c.hostname);
+        }
+        await this.execute(zone, actual, plan);
+        if (tunnelDomain) {
+          for (const h of ownedTunnelHostnames(actual, tunnelDomain, this.config)) {
+            managedTunnelHostnames.add(h);
+          }
+        }
+      } catch (err) {
+        console.error(`[cloudflare] zone ${zone.name}: sync failed:`, err);
+      }
+    }
+
+    if (tunnelDomain) {
+      const routes = tunnelRoutes.filter(
+        (t) => !conflictedHostnames.has(t.hostname) && !byZone.dropped.has(t.hostname),
+      );
+      // managedTunnelHostnames holds only hostnames PROVEN ours via the TXT
+      // registry before this run — a pre-existing ingress rule for a desired
+      // hostname we do not own must surface as a conflict, never be replaced.
+      await this.syncTunnelIngress(routes, managedTunnelHostnames);
+    }
+  }
+
+  /** Resolves the tunnel CNAME target, or undefined when tunnel sync is unavailable. */
+  private tunnelDomain(routes: TunnelRoute[]): string | undefined {
+    if (routes.length === 0 && !this.config.cloudflare.tunnelId) return undefined;
+    const { accountId, tunnelId } = this.config.cloudflare;
+    if (!accountId || !tunnelId) {
+      if (routes.length > 0) {
+        console.warn(
+          `[cloudflare] ${routes.length} tunnel route(s) requested but ` +
+            `CLOUDFLARE_ACCOUNT_ID/CLOUDFLARE_TUNNEL_ID are not set — skipping tunnel sync`,
+        );
+      }
+      return undefined;
+    }
+    return `${tunnelId}.cfargotunnel.com`;
+  }
+
+  private async matchingZones(): Promise<CfZone[]> {
+    const zones = await this.api.listZones();
+    const filter = this.config.domainFilter;
+    if (filter.length === 0) return zones;
+    return zones.filter((z) => filter.some((d) => z.name === d || z.name.endsWith(`.${d}`)));
+  }
+
+  private async fetchActual(zoneId: string): Promise<ActualEntry[]> {
+    const wire = await this.api.listDnsRecords(zoneId);
+    const entries: ActualEntry[] = [];
+    for (const record of wire) {
+      const registry = fromWire(record);
+      if (registry) entries.push({ registry, id: record.id });
+    }
+    return entries;
+  }
+
+  private async execute(zone: CfZone, actual: ActualEntry[], plan: Plan): Promise<void> {
+    const idFor = (record: RegistryRecord): string | undefined =>
+      actual.find(
+        (e) =>
+          e.registry === record ||
+          (e.registry.type === record.type && e.registry.hostname === record.hostname),
+      )?.id;
+
+    for (const record of plan.creates) {
+      await this.apiCall(`create ${record.type} ${record.hostname}`, () =>
+        this.api.createDnsRecord(zone.id, toWire(record)),
+      );
+    }
+    for (const record of plan.updates) {
+      const id = idFor(record);
+      if (!id) continue;
+      await this.apiCall(`update ${record.type} ${record.hostname}`, () =>
+        this.api.updateDnsRecord(zone.id, id, toWire(record)),
+      );
+    }
+    for (const record of plan.deletes) {
+      const id = idFor(record);
+      if (!id) continue;
+      await this.apiCall(`delete ${record.type} ${record.hostname}`, () =>
+        this.api.deleteDnsRecord(zone.id, id),
+      );
+    }
+  }
+
+  private async syncTunnelIngress(
+    routes: TunnelRoute[],
+    managedHostnames: Set<string>,
+  ): Promise<void> {
+    const { accountId, tunnelId } = this.config.cloudflare;
+    if (!accountId || !tunnelId) return;
+    try {
+      // Read immediately before writing to shrink the last-writer-wins window.
+      const config = (await this.api.getTunnelConfig(accountId, tunnelId)) ?? {};
+      const merged = mergeIngress({
+        current: config.ingress ?? [],
+        desired: routes.map((t) => ({ hostname: t.hostname, service: t.service })),
+        managedHostnames,
+        policy: this.config.policy,
+      });
+      for (const hostname of merged.conflicts) {
+        console.warn(
+          `[cloudflare] tunnel route ${hostname}: an unmanaged ingress rule claims this hostname — skipping`,
+        );
+      }
+      if (merged.changed) {
+        await this.api.putTunnelConfig(accountId, tunnelId, { ...config, ingress: merged.ingress });
+        console.log(`[cloudflare] tunnel ingress updated (${merged.ingress.length} rule(s))`);
+      }
+    } catch (err) {
+      console.error("[cloudflare] tunnel ingress sync failed:", err);
+    }
+  }
+
+  private async apiCall(what: string, call: () => Promise<void>): Promise<void> {
+    try {
+      await call();
+      console.log(`[cloudflare] ${what}`);
+    } catch (err) {
+      console.error(`[cloudflare] ${what} failed:`, err);
+    }
+  }
+}
+
+function toRegistry(record: DnsRecord): RegistryRecord {
+  const proxied = record.providerSpecific?.[PROXIED_HINT] === "true";
+  return {
+    hostname: record.hostname,
+    type: record.type,
+    content: record.target,
+    ttl: proxied ? PROXIED_TTL : record.ttl,
+    providerSpecific: { [PROXIED_HINT]: String(proxied) },
+    resource: `container/${record.source.slice(0, 12)}`,
+  };
+}
+
+function tunnelCname(route: TunnelRoute, tunnelDomain: string): RegistryRecord {
+  return {
+    hostname: route.hostname,
+    type: "CNAME",
+    content: tunnelDomain,
+    ttl: PROXIED_TTL,
+    providerSpecific: { [PROXIED_HINT]: "true" },
+    resource: `container/${route.source.slice(0, 12)}`,
+  };
+}
+
+function fromWire(record: CfDnsRecord): RegistryRecord | undefined {
+  if (record.type === "TXT") {
+    return { hostname: record.name, type: "TXT", content: record.content, ttl: record.ttl };
+  }
+  if (record.type !== "A" && record.type !== "AAAA" && record.type !== "CNAME") return undefined;
+  const proxied = record.proxied === true;
+  return {
+    hostname: record.name,
+    type: record.type,
+    content: record.content,
+    ttl: proxied ? PROXIED_TTL : record.ttl,
+    providerSpecific: { [PROXIED_HINT]: String(proxied) },
+  };
+}
+
+function toWire(record: RegistryRecord): CfDnsRecordInput {
+  return {
+    type: record.type,
+    name: record.hostname,
+    content: record.content,
+    ttl: record.ttl,
+    ...(record.type !== "TXT"
+      ? { proxied: record.providerSpecific?.[PROXIED_HINT] === "true" }
+      : {}),
+  };
+}
+
+/** Hostnames whose tunnel CNAME already exists AND carries our ownership TXT. */
+function ownedTunnelHostnames(
+  actual: ActualEntry[],
+  tunnelDomain: string,
+  config: Config,
+): string[] {
+  const ownedCnames = new Set<string>();
+  for (const { registry } of actual) {
+    if (registry.type !== "TXT") continue;
+    const txtName = parseTxtName(registry.hostname, config.txtPrefix);
+    if (!txtName || txtName.type !== "CNAME") continue;
+    if (parseOwnershipContent(registry.content)?.owner === config.ownerId) {
+      ownedCnames.add(txtName.hostname);
+    }
+  }
+  return actual
+    .filter(
+      (e) =>
+        e.registry.type === "CNAME" &&
+        e.registry.content === tunnelDomain &&
+        ownedCnames.has(e.registry.hostname),
+    )
+    .map((e) => e.registry.hostname);
+}
+
+function groupByZone(
+  records: RegistryRecord[],
+  zones: CfZone[],
+): { perZone: Map<string, RegistryRecord[]>; dropped: Set<string> } {
+  const perZone = new Map<string, RegistryRecord[]>();
+  const dropped = new Set<string>();
+  for (const record of records) {
+    const zone = longestSuffixMatch(record.hostname, zones);
+    if (!zone) {
+      dropped.add(record.hostname);
+      continue;
+    }
+    const list = perZone.get(zone.id) ?? [];
+    list.push(record);
+    perZone.set(zone.id, list);
+  }
+  return { perZone, dropped };
+}
+
+function longestSuffixMatch(hostname: string, zones: CfZone[]): CfZone | undefined {
+  let best: CfZone | undefined;
+  for (const zone of zones) {
+    if (hostname !== zone.name && !hostname.endsWith(`.${zone.name}`)) continue;
+    if (!best || zone.name.length > best.name.length) best = zone;
+  }
+  return best;
+}
+
+registerProvider("cloudflare", (config) => {
+  const token = config.cloudflare.apiToken;
+  if (!token) throw new Error("CLOUDFLARE_API_TOKEN is required for the cloudflare provider");
+  return new CloudflareProvider(new CloudflareFetchApi(token), config);
+});

--- a/src/providers/cloudflare/cloudflare.ts
+++ b/src/providers/cloudflare/cloudflare.ts
@@ -1,14 +1,14 @@
 import type { Config } from "../../config";
 import type { DesiredState, DnsRecord, TunnelRoute } from "../../core/types";
-import { registerProvider, type Provider } from "../provider";
-import { planChanges, type Plan, type RegistryRecord } from "../registry/planner";
+import { type Provider, registerProvider } from "../provider";
 import { parseOwnershipContent, parseTxtName } from "../registry/ownership";
+import { type Plan, planChanges, type RegistryRecord } from "../registry/planner";
 import {
-  CloudflareFetchApi,
   type CfDnsRecord,
   type CfDnsRecordInput,
   type CfZone,
   type CloudflareApi,
+  CloudflareFetchApi,
 } from "./api";
 import { mergeIngress } from "./tunnel";
 
@@ -246,7 +246,7 @@ function ownedTunnelHostnames(
   for (const { registry } of actual) {
     if (registry.type !== "TXT") continue;
     const txtName = parseTxtName(registry.hostname, config.txtPrefix);
-    if (!txtName || txtName.type !== "CNAME") continue;
+    if (txtName?.type !== "CNAME") continue;
     if (parseOwnershipContent(registry.content)?.owner === config.ownerId) {
       ownedCnames.add(txtName.hostname);
     }

--- a/src/providers/cloudflare/tunnel.test.ts
+++ b/src/providers/cloudflare/tunnel.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import type { CfIngressRule } from "./api";
+import { mergeIngress, type MergeIngressInput } from "./tunnel";
+
+const CATCH_ALL: CfIngressRule = { service: "http_status:404" };
+
+function merge(input: Partial<MergeIngressInput>) {
+  return mergeIngress({
+    current: [],
+    desired: [],
+    managedHostnames: new Set(),
+    policy: "sync",
+    ...input,
+  });
+}
+
+describe("mergeIngress", () => {
+  test("adds managed rules and a catch-all to an empty ingress", () => {
+    const result = merge({
+      desired: [{ hostname: "a.example.com", service: "http://a:80" }],
+      managedHostnames: new Set(["a.example.com"]),
+    });
+    expect(result.changed).toBe(true);
+    expect(result.ingress).toEqual([
+      { hostname: "a.example.com", service: "http://a:80" },
+      CATCH_ALL,
+    ]);
+  });
+
+  test("leaves a tunnel it has no business with untouched", () => {
+    const foreign = [{ hostname: "other.example.com", service: "http://other:80" }, CATCH_ALL];
+    expect(merge({ current: [] }).changed).toBe(false);
+    const result = merge({ current: foreign });
+    expect(result.changed).toBe(false);
+    expect(result.ingress).toEqual(foreign);
+  });
+
+  test("preserves unmanaged rules in original order, before managed ones", () => {
+    const result = merge({
+      current: [
+        { hostname: "keep.example.com", service: "http://keep:80" },
+        { hostname: "old.example.com", service: "http://old:80" },
+        CATCH_ALL,
+      ],
+      desired: [
+        { hostname: "z.example.com", service: "http://z:80" },
+        { hostname: "old.example.com", service: "http://new:80" },
+      ],
+      managedHostnames: new Set(["old.example.com", "z.example.com"]),
+    });
+    expect(result.ingress).toEqual([
+      { hostname: "keep.example.com", service: "http://keep:80" },
+      { hostname: "old.example.com", service: "http://new:80" },
+      { hostname: "z.example.com", service: "http://z:80" },
+      CATCH_ALL,
+    ]);
+  });
+
+  test("an unmanaged rule claiming a desired hostname is a conflict", () => {
+    const current = [{ hostname: "a.example.com", service: "http://theirs:80" }, CATCH_ALL];
+    const result = merge({
+      current,
+      desired: [{ hostname: "a.example.com", service: "http://ours:80" }],
+      managedHostnames: new Set(), // not owned by us
+    });
+    expect(result.conflicts).toEqual(["a.example.com"]);
+    expect(result.changed).toBe(false);
+    expect(result.ingress).toEqual(current);
+  });
+
+  test("preserves extra settings when updating a managed rule", () => {
+    const result = merge({
+      current: [
+        { hostname: "a.example.com", service: "http://old:80", originRequest: { noTLSVerify: true } },
+        CATCH_ALL,
+      ],
+      desired: [{ hostname: "a.example.com", service: "http://new:80" }],
+      managedHostnames: new Set(["a.example.com"]),
+    });
+    expect(result.ingress[0]).toEqual({
+      hostname: "a.example.com",
+      service: "http://new:80",
+      originRequest: { noTLSVerify: true },
+    });
+  });
+
+  test("sync removes orphaned managed rules", () => {
+    const result = merge({
+      current: [{ hostname: "gone.example.com", service: "http://gone:80" }, CATCH_ALL],
+      managedHostnames: new Set(["gone.example.com"]),
+    });
+    expect(result.changed).toBe(true);
+    expect(result.ingress).toEqual([CATCH_ALL]);
+  });
+
+  test("upsert-only keeps orphaned managed rules", () => {
+    const current = [{ hostname: "gone.example.com", service: "http://gone:80" }, CATCH_ALL];
+    const result = merge({
+      policy: "upsert-only",
+      current,
+      managedHostnames: new Set(["gone.example.com"]),
+    });
+    expect(result.changed).toBe(false);
+    expect(result.ingress).toEqual(current);
+  });
+
+  test("create-only never updates an existing managed rule", () => {
+    const result = merge({
+      policy: "create-only",
+      current: [{ hostname: "a.example.com", service: "http://old:80" }, CATCH_ALL],
+      desired: [
+        { hostname: "a.example.com", service: "http://new:80" },
+        { hostname: "b.example.com", service: "http://b:80" },
+      ],
+      managedHostnames: new Set(["a.example.com", "b.example.com"]),
+    });
+    expect(result.ingress).toEqual([
+      { hostname: "a.example.com", service: "http://old:80" },
+      { hostname: "b.example.com", service: "http://b:80" },
+      CATCH_ALL,
+    ]);
+  });
+
+  test("reports no change when the merged ingress is identical", () => {
+    const current = [{ hostname: "a.example.com", service: "http://a:80" }, CATCH_ALL];
+    const result = merge({
+      current,
+      desired: [{ hostname: "a.example.com", service: "http://a:80" }],
+      managedHostnames: new Set(["a.example.com"]),
+    });
+    expect(result.changed).toBe(false);
+  });
+});

--- a/src/providers/cloudflare/tunnel.test.ts
+++ b/src/providers/cloudflare/tunnel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { CfIngressRule } from "./api";
-import { mergeIngress, type MergeIngressInput } from "./tunnel";
+import { type MergeIngressInput, mergeIngress } from "./tunnel";
 
 const CATCH_ALL: CfIngressRule = { service: "http_status:404" };
 
@@ -71,7 +71,11 @@ describe("mergeIngress", () => {
   test("preserves extra settings when updating a managed rule", () => {
     const result = merge({
       current: [
-        { hostname: "a.example.com", service: "http://old:80", originRequest: { noTLSVerify: true } },
+        {
+          hostname: "a.example.com",
+          service: "http://old:80",
+          originRequest: { noTLSVerify: true },
+        },
         CATCH_ALL,
       ],
       desired: [{ hostname: "a.example.com", service: "http://new:80" }],

--- a/src/providers/cloudflare/tunnel.ts
+++ b/src/providers/cloudflare/tunnel.ts
@@ -1,0 +1,94 @@
+import type { Policy } from "../../config";
+import type { CfIngressRule } from "./api";
+
+/**
+ * Pure merge of DockRoute-managed routes into a tunnel's ingress list.
+ *
+ * Cloudflare's tunnel configuration PUT replaces the WHOLE ingress list, so
+ * the merge must never clobber rules DockRoute does not manage. A rule is
+ * managed iff its hostname is in managedHostnames (derived from the TXT
+ * ownership registry by the caller). Output order:
+ *   unmanaged rules (original order) + managed rules (sorted) + catch-all.
+ * Unmanaged rules keep their original position first so a pre-existing rule
+ * never starts being shadowed by ours.
+ */
+
+export interface DesiredIngressRoute {
+  hostname: string;
+  service: string;
+}
+
+export interface MergeIngressInput {
+  current: CfIngressRule[];
+  desired: DesiredIngressRoute[];
+  managedHostnames: Set<string>;
+  policy: Policy;
+}
+
+export interface MergeIngressResult {
+  ingress: CfIngressRule[];
+  changed: boolean;
+  /** Hostnames whose desired route was skipped because an unmanaged rule claims them. */
+  conflicts: string[];
+}
+
+const CATCH_ALL: CfIngressRule = { service: "http_status:404" };
+
+export function mergeIngress({
+  current,
+  desired,
+  managedHostnames,
+  policy,
+}: MergeIngressInput): MergeIngressResult {
+  const last = current[current.length - 1];
+  const catchAll = last && last.hostname === undefined ? last : CATCH_ALL;
+  const rules = last && last.hostname === undefined ? current.slice(0, -1) : current;
+
+  const unmanaged = rules.filter((r) => r.hostname === undefined || !managedHostnames.has(r.hostname));
+  const existingManaged = rules.filter((r) => r.hostname !== undefined && managedHostnames.has(r.hostname));
+  const unmanagedHostnames = new Set(unmanaged.map((r) => r.hostname).filter((h) => h !== undefined));
+
+  const conflicts = desired.filter((d) => unmanagedHostnames.has(d.hostname)).map((d) => d.hostname);
+  const wanted = desired.filter((d) => !unmanagedHostnames.has(d.hostname));
+
+  const managed = mergeManaged(existingManaged, wanted, policy);
+  managed.sort((a, b) => (a.hostname ?? "").localeCompare(b.hostname ?? ""));
+
+  if (existingManaged.length === 0 && managed.length === 0) {
+    // Nothing of ours in the tunnel and nothing to add — leave it untouched
+    // (avoids writing a catch-all into a tunnel we have no business with).
+    return { ingress: current, changed: false, conflicts };
+  }
+
+  const ingress = [...unmanaged, ...managed, catchAll];
+  return {
+    ingress,
+    changed: JSON.stringify(ingress) !== JSON.stringify(current),
+    conflicts,
+  };
+}
+
+function mergeManaged(
+  existing: CfIngressRule[],
+  wanted: DesiredIngressRoute[],
+  policy: Policy,
+): CfIngressRule[] {
+  const existingByHostname = new Map(existing.map((r) => [r.hostname, r]));
+  // Preserve extra per-rule settings (e.g. originRequest) when updating our rules.
+  const updated = wanted.map((d) => ({
+    ...existingByHostname.get(d.hostname),
+    hostname: d.hostname,
+    service: d.service,
+  }));
+
+  switch (policy) {
+    case "sync":
+      return updated;
+    case "upsert-only": {
+      const wantedHostnames = new Set(wanted.map((d) => d.hostname));
+      return [...updated, ...existing.filter((r) => !wantedHostnames.has(r.hostname as string))];
+    }
+    case "create-only":
+      return [...existing, ...updated.filter((r) => !existingByHostname.has(r.hostname))];
+  }
+}

--- a/src/providers/cloudflare/tunnel.ts
+++ b/src/providers/cloudflare/tunnel.ts
@@ -44,11 +44,19 @@ export function mergeIngress({
   const catchAll = last && last.hostname === undefined ? last : CATCH_ALL;
   const rules = last && last.hostname === undefined ? current.slice(0, -1) : current;
 
-  const unmanaged = rules.filter((r) => r.hostname === undefined || !managedHostnames.has(r.hostname));
-  const existingManaged = rules.filter((r) => r.hostname !== undefined && managedHostnames.has(r.hostname));
-  const unmanagedHostnames = new Set(unmanaged.map((r) => r.hostname).filter((h) => h !== undefined));
+  const unmanaged = rules.filter(
+    (r) => r.hostname === undefined || !managedHostnames.has(r.hostname),
+  );
+  const existingManaged = rules.filter(
+    (r) => r.hostname !== undefined && managedHostnames.has(r.hostname),
+  );
+  const unmanagedHostnames = new Set(
+    unmanaged.map((r) => r.hostname).filter((h) => h !== undefined),
+  );
 
-  const conflicts = desired.filter((d) => unmanagedHostnames.has(d.hostname)).map((d) => d.hostname);
+  const conflicts = desired
+    .filter((d) => unmanagedHostnames.has(d.hostname))
+    .map((d) => d.hostname);
   const wanted = desired.filter((d) => !unmanagedHostnames.has(d.hostname));
 
   const managed = mergeManaged(existingManaged, wanted, policy);

--- a/src/providers/log.ts
+++ b/src/providers/log.ts
@@ -1,5 +1,5 @@
 import type { DesiredState } from "../core/types";
-import { registerProvider, type Provider } from "./provider";
+import { type Provider, registerProvider } from "./provider";
 
 /** Dry-run provider: prints the desired state instead of writing DNS. */
 class LogProvider implements Provider {
@@ -7,12 +7,18 @@ class LogProvider implements Provider {
 
   async sync(desired: DesiredState): Promise<void> {
     const { records, tunnelRoutes } = desired;
-    console.log(`[log] desired state: ${records.length} record(s), ${tunnelRoutes.length} tunnel route(s)`);
+    console.log(
+      `[log] desired state: ${records.length} record(s), ${tunnelRoutes.length} tunnel route(s)`,
+    );
     for (const r of records) {
-      console.log(`[log]   ${r.hostname} ${r.ttl} IN ${r.type} ${r.target} (from ${r.source.slice(0, 12)})`);
+      console.log(
+        `[log]   ${r.hostname} ${r.ttl} IN ${r.type} ${r.target} (from ${r.source.slice(0, 12)})`,
+      );
     }
     for (const t of tunnelRoutes) {
-      console.log(`[log]   ${t.hostname} -> tunnel -> ${t.service} (from ${t.source.slice(0, 12)})`);
+      console.log(
+        `[log]   ${t.hostname} -> tunnel -> ${t.service} (from ${t.source.slice(0, 12)})`,
+      );
     }
   }
 }

--- a/src/providers/log.ts
+++ b/src/providers/log.ts
@@ -1,0 +1,20 @@
+import type { DesiredState } from "../core/types";
+import { registerProvider, type Provider } from "./provider";
+
+/** Dry-run provider: prints the desired state instead of writing DNS. */
+class LogProvider implements Provider {
+  readonly name = "log";
+
+  async sync(desired: DesiredState): Promise<void> {
+    const { records, tunnelRoutes } = desired;
+    console.log(`[log] desired state: ${records.length} record(s), ${tunnelRoutes.length} tunnel route(s)`);
+    for (const r of records) {
+      console.log(`[log]   ${r.hostname} ${r.ttl} IN ${r.type} ${r.target} (from ${r.source.slice(0, 12)})`);
+    }
+    for (const t of tunnelRoutes) {
+      console.log(`[log]   ${t.hostname} -> tunnel -> ${t.service} (from ${t.source.slice(0, 12)})`);
+    }
+  }
+}
+
+registerProvider("log", () => new LogProvider());

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,0 +1,29 @@
+import type { Config } from "../config";
+import type { DesiredState } from "../core/types";
+
+/**
+ * A DNS provider receives the FULL desired state on every reconcile and owns
+ * the diff against its actual state (create / update / delete). Providers
+ * without tunnel support must warn and skip tunnelRoutes, never throw.
+ */
+export interface Provider {
+  readonly name: string;
+  sync(desired: DesiredState): Promise<void>;
+}
+
+type ProviderFactory = (config: Config) => Provider;
+
+const registry = new Map<string, ProviderFactory>();
+
+export function registerProvider(name: string, factory: ProviderFactory): void {
+  registry.set(name, factory);
+}
+
+export function createProvider(name: string, config: Config): Provider {
+  const factory = registry.get(name);
+  if (!factory) {
+    const known = [...registry.keys()].join(", ");
+    throw new Error(`Unknown provider "${name}". Available: ${known}`);
+  }
+  return factory(config);
+}

--- a/src/providers/registry/ownership.test.ts
+++ b/src/providers/registry/ownership.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatOwnershipContent,
+  parseOwnershipContent,
+  parseTxtName,
+  txtNameFor,
+} from "./ownership";
+
+const PREFIX = "_dockroute-";
+
+describe("ownership content", () => {
+  test("format/parse round-trip", () => {
+    const content = formatOwnershipContent({ owner: "home-lab", resource: "container/whoami" });
+    expect(content).toBe("heritage=dockroute,dockroute/owner=home-lab,dockroute/resource=container/whoami");
+    expect(parseOwnershipContent(content)).toEqual({ owner: "home-lab", resource: "container/whoami" });
+  });
+
+  test("resource is optional", () => {
+    const content = formatOwnershipContent({ owner: "default" });
+    expect(parseOwnershipContent(content)).toEqual({ owner: "default", resource: undefined });
+  });
+
+  test("parses provider-quoted content", () => {
+    expect(parseOwnershipContent('"heritage=dockroute,dockroute/owner=x"')?.owner).toBe("x");
+  });
+
+  test("rejects foreign heritage and unrelated TXT content", () => {
+    expect(parseOwnershipContent("heritage=external-dns,external-dns/owner=x")).toBeUndefined();
+    expect(parseOwnershipContent("v=spf1 include:_spf.google.com ~all")).toBeUndefined();
+    expect(parseOwnershipContent("heritage=dockroute")).toBeUndefined();
+  });
+});
+
+describe("txt naming", () => {
+  test("name round-trips for every record type", () => {
+    for (const type of ["A", "AAAA", "CNAME"] as const) {
+      const name = txtNameFor("whoami.example.com", type, PREFIX);
+      expect(name).toBe(`${PREFIX}${type.toLowerCase()}.whoami.example.com`);
+      expect(parseTxtName(name, PREFIX)).toEqual({ hostname: "whoami.example.com", type });
+    }
+  });
+
+  test("round-trips for apex hostnames", () => {
+    const name = txtNameFor("example.com", "A", PREFIX);
+    expect(parseTxtName(name, PREFIX)).toEqual({ hostname: "example.com", type: "A" });
+  });
+
+  test("rejects non-registry TXT names", () => {
+    expect(parseTxtName("whoami.example.com", PREFIX)).toBeUndefined();
+    expect(parseTxtName("_dmarc.example.com", PREFIX)).toBeUndefined();
+    expect(parseTxtName(`${PREFIX}mx.example.com`, PREFIX)).toBeUndefined();
+    expect(parseTxtName(`${PREFIX}a`, PREFIX)).toBeUndefined();
+  });
+});

--- a/src/providers/registry/ownership.test.ts
+++ b/src/providers/registry/ownership.test.ts
@@ -11,8 +11,13 @@ const PREFIX = "_dockroute-";
 describe("ownership content", () => {
   test("format/parse round-trip", () => {
     const content = formatOwnershipContent({ owner: "home-lab", resource: "container/whoami" });
-    expect(content).toBe("heritage=dockroute,dockroute/owner=home-lab,dockroute/resource=container/whoami");
-    expect(parseOwnershipContent(content)).toEqual({ owner: "home-lab", resource: "container/whoami" });
+    expect(content).toBe(
+      "heritage=dockroute,dockroute/owner=home-lab,dockroute/resource=container/whoami",
+    );
+    expect(parseOwnershipContent(content)).toEqual({
+      owner: "home-lab",
+      resource: "container/whoami",
+    });
   });
 
   test("resource is optional", () => {

--- a/src/providers/registry/ownership.ts
+++ b/src/providers/registry/ownership.ts
@@ -1,0 +1,66 @@
+import type { RecordType } from "../../core/types";
+
+/**
+ * ExternalDNS-style TXT ownership registry (provider-agnostic).
+ *
+ * Every data record DockRoute manages gets a companion TXT record:
+ *   name:    <prefix><type-lowercase>.<hostname>   e.g. _dockroute-a.whoami.example.com
+ *   content: heritage=dockroute,dockroute/owner=<ownerId>[,dockroute/resource=<resource>]
+ *
+ * A record is "owned" only when the companion TXT exists, carries
+ * heritage=dockroute AND the matching owner id. DockRoute never modifies or
+ * deletes anything it does not own.
+ */
+
+const HERITAGE = "dockroute";
+
+export interface Ownership {
+  owner: string;
+  /** Informational only (e.g. container/whoami); never used for ownership checks. */
+  resource?: string;
+}
+
+export function formatOwnershipContent(ownership: Ownership): string {
+  const parts = [`heritage=${HERITAGE}`, `dockroute/owner=${ownership.owner}`];
+  if (ownership.resource) parts.push(`dockroute/resource=${ownership.resource}`);
+  return parts.join(",");
+}
+
+/** Parses TXT content; returns undefined unless heritage=dockroute. */
+export function parseOwnershipContent(content: string): Ownership | undefined {
+  const fields = new Map<string, string>();
+  for (const part of stripQuotes(content).split(",")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) return undefined;
+    fields.set(part.slice(0, eq).trim(), part.slice(eq + 1).trim());
+  }
+  if (fields.get("heritage") !== HERITAGE) return undefined;
+  const owner = fields.get("dockroute/owner");
+  if (owner === undefined) return undefined;
+  return { owner, resource: fields.get("dockroute/resource") };
+}
+
+export function txtNameFor(hostname: string, type: RecordType, prefix: string): string {
+  return `${prefix}${type.toLowerCase()}.${hostname}`;
+}
+
+export interface TxtName {
+  hostname: string;
+  type: RecordType;
+}
+
+/** Reverses txtNameFor; returns undefined for TXT names not in registry format. */
+export function parseTxtName(name: string, prefix: string): TxtName | undefined {
+  const [first, ...rest] = name.split(".");
+  if (!first || rest.length === 0 || !first.startsWith(prefix)) return undefined;
+  const type = first.slice(prefix.length).toUpperCase();
+  if (type !== "A" && type !== "AAAA" && type !== "CNAME") return undefined;
+  return { hostname: rest.join("."), type };
+}
+
+/** Providers may hand back TXT content wrapped in quotes; normalize it. */
+function stripQuotes(content: string): string {
+  return content.length >= 2 && content.startsWith('"') && content.endsWith('"')
+    ? content.slice(1, -1)
+    : content;
+}

--- a/src/providers/registry/planner.test.ts
+++ b/src/providers/registry/planner.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import { formatOwnershipContent } from "./ownership";
+import { planChanges, type PlanInput, type RegistryRecord } from "./planner";
+
+const PREFIX = "_dockroute-";
+const OWNER = "home-lab";
+
+function rec(hostname: string, over: Partial<RegistryRecord> = {}): RegistryRecord {
+  return { hostname, type: "A", content: "10.0.0.1", ttl: 300, ...over };
+}
+
+function ownedTxt(hostname: string, type = "a", owner = OWNER): RegistryRecord {
+  return {
+    hostname: `${PREFIX}${type}.${hostname}`,
+    type: "TXT",
+    content: formatOwnershipContent({ owner }),
+    ttl: 300,
+  };
+}
+
+function plan(input: Partial<PlanInput>) {
+  return planChanges({
+    desired: [],
+    actual: [],
+    ownerId: OWNER,
+    txtPrefix: PREFIX,
+    policy: "sync",
+    ...input,
+  });
+}
+
+describe("planChanges — creates", () => {
+  test("new record is created together with its ownership TXT", () => {
+    const p = plan({ desired: [rec("a.example.com", { resource: "container/whoami" })] });
+    expect(p.creates).toEqual([
+      rec("a.example.com", { resource: "container/whoami" }),
+      {
+        hostname: "_dockroute-a.a.example.com",
+        type: "TXT",
+        content: formatOwnershipContent({ owner: OWNER, resource: "container/whoami" }),
+        ttl: 300,
+      },
+    ]);
+    expect(p.updates).toEqual([]);
+    expect(p.deletes).toEqual([]);
+    expect(p.conflicts).toEqual([]);
+  });
+
+  test("dangling owned TXT: record is recreated without a duplicate TXT", () => {
+    const p = plan({
+      desired: [rec("a.example.com")],
+      actual: [ownedTxt("a.example.com")],
+    });
+    expect(p.creates).toEqual([rec("a.example.com")]);
+    expect(p.deletes).toEqual([]);
+  });
+});
+
+describe("planChanges — updates", () => {
+  test("updates only when content, ttl or provider hints differ", () => {
+    const unchanged = plan({
+      desired: [rec("a.example.com")],
+      actual: [rec("a.example.com"), ownedTxt("a.example.com")],
+    });
+    expect(unchanged.updates).toEqual([]);
+    expect(unchanged.creates).toEqual([]);
+
+    const changed = plan({
+      desired: [rec("a.example.com", { content: "10.0.0.2" })],
+      actual: [rec("a.example.com"), ownedTxt("a.example.com")],
+    });
+    expect(changed.updates).toEqual([rec("a.example.com", { content: "10.0.0.2" })]);
+
+    const hintChanged = plan({
+      desired: [rec("a.example.com", { providerSpecific: { "cloudflare.proxied": "true" } })],
+      actual: [
+        rec("a.example.com", { providerSpecific: { "cloudflare.proxied": "false" } }),
+        ownedTxt("a.example.com"),
+      ],
+    });
+    expect(hintChanged.updates).toHaveLength(1);
+  });
+});
+
+describe("planChanges — conflicts (never touch what we do not own)", () => {
+  test.each(["sync", "upsert-only", "create-only"] as const)(
+    "existing record without ownership TXT is a conflict under %s",
+    (policy) => {
+      const p = plan({
+        policy,
+        desired: [rec("a.example.com", { content: "10.9.9.9" })],
+        actual: [rec("a.example.com")],
+      });
+      expect(p.conflicts).toHaveLength(1);
+      expect(p.creates).toEqual([]);
+      expect(p.updates).toEqual([]);
+      expect(p.deletes).toEqual([]);
+    },
+  );
+
+  test("record owned by another instance is a conflict", () => {
+    const p = plan({
+      desired: [rec("a.example.com", { content: "10.9.9.9" })],
+      actual: [rec("a.example.com"), ownedTxt("a.example.com", "a", "other-instance")],
+    });
+    expect(p.conflicts[0]?.reason).toContain("other-instance");
+    expect(p.updates).toEqual([]);
+    expect(p.deletes).toEqual([]);
+  });
+
+  test("dangling foreign TXT blocks creation", () => {
+    const p = plan({
+      desired: [rec("a.example.com")],
+      actual: [ownedTxt("a.example.com", "a", "other-instance")],
+    });
+    expect(p.creates).toEqual([]);
+    expect(p.conflicts).toHaveLength(1);
+  });
+
+  test("foreign-owned orphans are never deleted", () => {
+    const p = plan({
+      actual: [rec("a.example.com"), ownedTxt("a.example.com", "a", "other-instance")],
+    });
+    expect(p.deletes).toEqual([]);
+  });
+});
+
+describe("planChanges — policies and orphans", () => {
+  const orphanActual = [rec("gone.example.com"), ownedTxt("gone.example.com")];
+
+  test("sync deletes owned orphans together with their TXT", () => {
+    const p = plan({ actual: orphanActual });
+    expect(p.deletes).toEqual(orphanActual);
+  });
+
+  test("sync cleans up dangling owned TXT when the hostname is no longer desired", () => {
+    const p = plan({ actual: [ownedTxt("gone.example.com")] });
+    expect(p.deletes).toEqual([ownedTxt("gone.example.com")]);
+  });
+
+  test("upsert-only never deletes", () => {
+    const p = plan({ policy: "upsert-only", actual: orphanActual });
+    expect(p.deletes).toEqual([]);
+  });
+
+  test("upsert-only still updates owned records", () => {
+    const p = plan({
+      policy: "upsert-only",
+      desired: [rec("a.example.com", { content: "10.0.0.2" })],
+      actual: [rec("a.example.com"), ownedTxt("a.example.com")],
+    });
+    expect(p.updates).toHaveLength(1);
+  });
+
+  test("create-only never updates nor deletes", () => {
+    const p = plan({
+      policy: "create-only",
+      desired: [rec("a.example.com", { content: "10.0.0.2" }), rec("new.example.com")],
+      actual: [rec("a.example.com"), ownedTxt("a.example.com"), ...orphanActual],
+    });
+    expect(p.updates).toEqual([]);
+    expect(p.deletes).toEqual([]);
+    expect(p.creates.map((r) => r.hostname)).toEqual(["new.example.com", "_dockroute-a.new.example.com"]);
+  });
+
+  test("same hostname with different record types is tracked independently", () => {
+    const p = plan({
+      desired: [rec("a.example.com"), rec("a.example.com", { type: "AAAA", content: "::1" })],
+      actual: [rec("a.example.com"), ownedTxt("a.example.com")],
+    });
+    expect(p.creates.map((r) => r.hostname)).toEqual(["a.example.com", "_dockroute-aaaa.a.example.com"]);
+    expect(p.updates).toEqual([]);
+  });
+});

--- a/src/providers/registry/planner.test.ts
+++ b/src/providers/registry/planner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { formatOwnershipContent } from "./ownership";
-import { planChanges, type PlanInput, type RegistryRecord } from "./planner";
+import { type PlanInput, planChanges, type RegistryRecord } from "./planner";
 
 const PREFIX = "_dockroute-";
 const OWNER = "home-lab";
@@ -160,7 +160,10 @@ describe("planChanges — policies and orphans", () => {
     });
     expect(p.updates).toEqual([]);
     expect(p.deletes).toEqual([]);
-    expect(p.creates.map((r) => r.hostname)).toEqual(["new.example.com", "_dockroute-a.new.example.com"]);
+    expect(p.creates.map((r) => r.hostname)).toEqual([
+      "new.example.com",
+      "_dockroute-a.new.example.com",
+    ]);
   });
 
   test("same hostname with different record types is tracked independently", () => {
@@ -168,7 +171,10 @@ describe("planChanges — policies and orphans", () => {
       desired: [rec("a.example.com"), rec("a.example.com", { type: "AAAA", content: "::1" })],
       actual: [rec("a.example.com"), ownedTxt("a.example.com")],
     });
-    expect(p.creates.map((r) => r.hostname)).toEqual(["a.example.com", "_dockroute-aaaa.a.example.com"]);
+    expect(p.creates.map((r) => r.hostname)).toEqual([
+      "a.example.com",
+      "_dockroute-aaaa.a.example.com",
+    ]);
     expect(p.updates).toEqual([]);
   });
 });

--- a/src/providers/registry/planner.ts
+++ b/src/providers/registry/planner.ts
@@ -63,7 +63,10 @@ export function planChanges({ desired, actual, ownerId, txtPrefix, policy }: Pla
       const txtName = parseTxtName(record.hostname, txtPrefix);
       const ownership = txtName && parseOwnershipContent(record.content);
       if (txtName && ownership) {
-        ownershipByKey.set(key(txtName.type, txtName.hostname), { owner: ownership.owner, txt: record });
+        ownershipByKey.set(key(txtName.type, txtName.hostname), {
+          owner: ownership.owner,
+          txt: record,
+        });
       }
     } else if (!dataByKey.has(key(record.type, record.hostname))) {
       dataByKey.set(key(record.type, record.hostname), record);
@@ -90,7 +93,11 @@ export function planChanges({ desired, actual, ownerId, txtPrefix, policy }: Pla
     }
 
     if (ownership && ownership.owner !== ownerId) {
-      conflict(plan, want, `hostname is claimed by owner "${ownership.owner}" (dangling ownership TXT)`);
+      conflict(
+        plan,
+        want,
+        `hostname is claimed by owner "${ownership.owner}" (dangling ownership TXT)`,
+      );
       continue;
     }
 

--- a/src/providers/registry/planner.ts
+++ b/src/providers/registry/planner.ts
@@ -1,0 +1,139 @@
+import type { Policy } from "../../config";
+import type { RecordType } from "../../core/types";
+import {
+  formatOwnershipContent,
+  parseOwnershipContent,
+  parseTxtName,
+  txtNameFor,
+} from "./ownership";
+
+/**
+ * Pure, provider-agnostic reconciliation planner. Providers map their wire
+ * records into RegistryRecords, run planChanges(), and execute the plan.
+ * All ownership and policy rules live here so every provider behaves the same.
+ */
+
+export type RegistryRecordType = RecordType | "TXT";
+
+export interface RegistryRecord {
+  hostname: string;
+  type: RegistryRecordType;
+  /** Record value: target for data records, ownership payload for TXT. */
+  content: string;
+  ttl: number;
+  /** Normalized provider hints; compared as part of "did the record change". */
+  providerSpecific?: Record<string, string>;
+  /** Informational resource written into the ownership TXT (desired only). */
+  resource?: string;
+}
+
+export interface Conflict {
+  hostname: string;
+  type: RegistryRecordType;
+  reason: string;
+}
+
+export interface Plan {
+  creates: RegistryRecord[];
+  /** New desired values; the provider matches the existing record by hostname+type. */
+  updates: RegistryRecord[];
+  /** Actual records to remove. */
+  deletes: RegistryRecord[];
+  conflicts: Conflict[];
+}
+
+export interface PlanInput {
+  /** Desired data records (no TXT), already deduped by hostname+type. */
+  desired: RegistryRecord[];
+  /** Actual records at the provider, including TXT. */
+  actual: RegistryRecord[];
+  ownerId: string;
+  txtPrefix: string;
+  policy: Policy;
+}
+
+export function planChanges({ desired, actual, ownerId, txtPrefix, policy }: PlanInput): Plan {
+  const plan: Plan = { creates: [], updates: [], deletes: [], conflicts: [] };
+
+  const dataByKey = new Map<string, RegistryRecord>();
+  const ownershipByKey = new Map<string, { owner: string; txt: RegistryRecord }>();
+
+  for (const record of actual) {
+    if (record.type === "TXT") {
+      const txtName = parseTxtName(record.hostname, txtPrefix);
+      const ownership = txtName && parseOwnershipContent(record.content);
+      if (txtName && ownership) {
+        ownershipByKey.set(key(txtName.type, txtName.hostname), { owner: ownership.owner, txt: record });
+      }
+    } else if (!dataByKey.has(key(record.type, record.hostname))) {
+      dataByKey.set(key(record.type, record.hostname), record);
+    }
+  }
+
+  const desiredKeys = new Set<string>();
+  for (const want of desired) {
+    if (want.type === "TXT") continue; // registry TXTs are planner-internal
+    const k = key(want.type, want.hostname);
+    desiredKeys.add(k);
+    const existing = dataByKey.get(k);
+    const ownership = ownershipByKey.get(k);
+
+    if (existing) {
+      if (!ownership) {
+        conflict(plan, want, `record exists but has no ownership TXT — not managed by dockroute`);
+      } else if (ownership.owner !== ownerId) {
+        conflict(plan, want, `record is owned by "${ownership.owner}", not "${ownerId}"`);
+      } else if (policy !== "create-only" && differs(existing, want)) {
+        plan.updates.push(want);
+      }
+      continue;
+    }
+
+    if (ownership && ownership.owner !== ownerId) {
+      conflict(plan, want, `hostname is claimed by owner "${ownership.owner}" (dangling ownership TXT)`);
+      continue;
+    }
+
+    plan.creates.push(want);
+    if (!ownership) {
+      plan.creates.push({
+        hostname: txtNameFor(want.hostname, want.type, txtPrefix),
+        type: "TXT",
+        content: formatOwnershipContent({ owner: ownerId, resource: want.resource }),
+        ttl: want.ttl,
+      });
+    }
+  }
+
+  if (policy === "sync") {
+    for (const [k, { owner, txt }] of ownershipByKey) {
+      if (owner !== ownerId || desiredKeys.has(k)) continue;
+      const orphan = dataByKey.get(k);
+      if (orphan) plan.deletes.push(orphan);
+      plan.deletes.push(txt);
+    }
+  }
+
+  return plan;
+}
+
+function key(type: RegistryRecordType, hostname: string): string {
+  return `${type}:${hostname}`;
+}
+
+function conflict(plan: Plan, record: RegistryRecord, reason: string): void {
+  plan.conflicts.push({ hostname: record.hostname, type: record.type, reason });
+}
+
+function differs(existing: RegistryRecord, want: RegistryRecord): boolean {
+  return (
+    existing.content !== want.content ||
+    existing.ttl !== want.ttl ||
+    !shallowEqual(existing.providerSpecific ?? {}, want.providerSpecific ?? {})
+  );
+}
+
+function shallowEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+  const keysA = Object.keys(a);
+  return keysA.length === Object.keys(b).length && keysA.every((k) => a[k] === b[k]);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "types": ["bun"],
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
…l routes

External-DNS for plain Docker hosts. Watches containers over the Docker socket, parses dockroute.* labels into desired state and reconciles it against a pluggable provider.

- Core pipeline: watcher (events + periodic resync), label parser, serialized/coalesced reconciler, provider registry, log (dry-run) provider
- Ownership: ExternalDNS-style TXT registry (_dockroute-<type>.<hostname>); records are never modified, deleted or adopted without proof of ownership
- Policies: sync (default) / upsert-only / create-only
- Cloudflare provider: zone resolution, pagination, proxied-TTL normalization, conflict detection, safe orphan cleanup
- Cloudflare Tunnel (existing-tunnel model): proxied CNAMEs to <tunnel-id>.cfargotunnel.com and ingress merge that preserves unmanaged rules and the catch-all, writing only on real diffs
- 71 unit tests against in-memory fakes; strict TypeScript; Bun runtime