### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @danilodorgam


### PR DESCRIPTION
## Summary

Adds .github/CODEOWNERS with @danilodorgam owning everything, backing the code owner review requirement now active in the protect-main ruleset.

## Test plan

CI runs on this PR; no code paths change.