### PR TITLE
ci: automate releases with semantic-release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,23 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore(ci)"
 
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly
     groups:
       dev-dependencies:
         dependency-type: development
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps)"
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "fix(deps)"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,17 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate conventional commit format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,15 @@ name: Release
 
 on:
   push:
-    tags: ["v*.*.*"]
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 env:
   IMAGE: ghcr.io/${{ github.repository_owner }}/dockroute
@@ -34,12 +38,46 @@ jobs:
       - name: Test
         run: bun test
 
+  release:
+    name: Semantic release
+    runs-on: ubuntu-latest
+    needs: verify
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      published: ${{ steps.semantic.outputs.new_release_published }}
+      version: ${{ steps.semantic.outputs.new_release_version }}
+      git_tag: ${{ steps.semantic.outputs.new_release_git_tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run semantic-release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v6
+        with:
+          extra_plugins: |
+            @semantic-release/changelog@7
+            @semantic-release/git@11
+            conventional-changelog-conventionalcommits@10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
     name: Publish image to GHCR
     runs-on: ubuntu-latest
-    needs: verify
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release.outputs.git_tag }}
 
       - uses: docker/setup-qemu-action@v4
 
@@ -77,8 +115,8 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.git_tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.git_tag }}
             type=raw,value=latest
 
       - name: Build and push (amd64 + arm64)
@@ -91,18 +129,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  release:
-    name: GitHub Release
-    runs-on: ubuntu-latest
-    needs: publish
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Create release with generated notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "${GITHUB_REF_NAME}" \
-            --generate-notes

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,18 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
+    ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
+    ["@semantic-release/npm", { "npmPublish": false }],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "package.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary

Replaces the manual tag-push release flow with [semantic-release](https://github.com/semantic-release/semantic-release):

- **Release workflow now triggers on push to `main`** (plus `workflow_dispatch` for manual reruns). semantic-release analyzes conventional commits since the last tag (`v0.1.0`), computes the next version, creates the git tag and the GitHub Release with generated notes, updates `CHANGELOG.md` and bumps `package.json` (committed back as `chore(release): x.y.z [skip ci]`).
- **Docker publish is chained** on `new_release_published`: builds from the release tag, keeps the Trivy gate, and pushes `x.y.z`, `x.y` and `latest` to GHCR.
- **PR title validation** (`amannn/action-semantic-pull-request`): with squash-only merges, the PR title becomes the commit that semantic-release parses.
- **Dependabot conventional prefixes**: runtime deps → `fix(deps)` (auto patch release), dev deps → `chore(deps)`, actions → `chore(ci)`; `npm` ecosystem switched to `bun` so `bun.lock` is tracked.

Config in `.releaserc.json` uses the `conventionalcommits` preset (notes grouped by Features / Bug Fixes / Performance).

## Notes

- Tag baseline `v0.1.0` already exists, so the next `fix:`/`feat:` merge releases `0.1.1`/`0.2.0`.
- `main` has no branch protection, so `GITHUB_TOKEN` is enough for the changelog commit push. If protection is added later, the workflow needs a GitHub App/PAT token.
- Commit types `chore`, `ci`, `docs`, etc. do not trigger a release (by design).