### PR TITLE
ci: push releases via dockroute-release-bot app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,17 +43,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
     outputs:
       published: ${{ steps.semantic.outputs.new_release_published }}
       version: ${{ steps.semantic.outputs.new_release_version }}
       git_tag: ${{ steps.semantic.outputs.new_release_git_tag }}
     steps:
+      # The release commit and tag are pushed as the dockroute-release-bot
+      # GitHub App, which has bypass on the protect-main ruleset.
+      - name: Mint release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run semantic-release
         id: semantic
@@ -64,7 +72,7 @@ jobs:
             @semantic-release/git@11
             conventional-changelog-conventionalcommits@10
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   publish:
     name: Publish image to GHCR


### PR DESCRIPTION
The `protect-main` ruleset requires changes via PR, which blocks the `chore(release)` commit push from `@semantic-release/git` when it runs with `GITHUB_TOKEN` (see the equivalent failure in dockroute-site).

The release job now mints an installation token for the **dockroute-release-bot** GitHub App (added as an always-bypass actor on the ruleset) via `actions/create-github-app-token`, and uses it for checkout, the release commit/tag push and the GitHub Release API. Job `GITHUB_TOKEN` permissions dropped to `contents: read` since the app token does all the writing.

Requires org/repo secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`.