### PR TITLE
fix(watcher): treat Bun fetch idle timeout as routine reconnect

### DIFF
--- a/src/docker/watcher.test.ts
+++ b/src/docker/watcher.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import type { Reconciler } from "../core/reconciler";
+import type { DockerClient } from "./client";
+import { Watcher } from "./watcher";
+
+const RESYNC_SECONDS = 3600;
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function fakeReconciler(): { reconciler: Reconciler; calls: { count: number } } {
+  const calls = { count: 0 };
+  const reconciler = {
+    reconcile: async () => {
+      calls.count++;
+    },
+  } as unknown as Reconciler;
+  return { reconciler, calls };
+}
+
+/**
+ * DockerClient whose event stream follows a script, one entry per connection:
+ * "timeout" / "error" throw on subscribe, "hang" stays open with no events.
+ */
+function scriptedDocker(
+  script: Array<"timeout" | "error" | "hang">,
+  onConnect: (connection: number) => void,
+): DockerClient {
+  let connection = 0;
+  return {
+    async *containerEvents() {
+      const step = script[Math.min(connection, script.length - 1)];
+      connection++;
+      onConnect(connection);
+      if (step === "timeout") throw new DOMException("The operation timed out.", "TimeoutError");
+      if (step === "error") throw new Error("boom");
+      await new Promise(() => {});
+    },
+  } as unknown as DockerClient;
+}
+
+describe("Watcher", () => {
+  let watcher: Watcher | undefined;
+  let errorSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    watcher?.stop();
+    errorSpy?.mockRestore();
+  });
+
+  test("timeout is a routine reconnect: immediate, silent, with a catch-up reconcile", async () => {
+    const { reconciler, calls } = fakeReconciler();
+    const reconnected = deferred();
+    const docker = scriptedDocker(["timeout", "hang"], (connection) => {
+      if (connection === 2) reconnected.resolve();
+    });
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    // A huge retryMs proves the reconnect did not wait for the retry delay.
+    watcher = new Watcher(docker, reconciler, RESYNC_SECONDS, 60_000);
+    await watcher.start();
+    await reconnected.promise;
+
+    expect(calls.count).toBe(2); // startup reconcile + catch-up after the drop
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  test("real errors log a single line and retry after the delay", async () => {
+    const { reconciler } = fakeReconciler();
+    const reconnected = deferred();
+    const docker = scriptedDocker(["error", "hang"], (connection) => {
+      if (connection === 2) reconnected.resolve();
+    });
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const started = performance.now();
+    watcher = new Watcher(docker, reconciler, RESYNC_SECONDS, 25);
+    await watcher.start();
+    await reconnected.promise;
+
+    expect(performance.now() - started).toBeGreaterThanOrEqual(20);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const args = errorSpy.mock.calls[0] as unknown[];
+    expect(args).toHaveLength(1); // one formatted string, not the raw error object
+    expect(String(args[0])).toContain("Error: boom");
+  });
+});

--- a/src/docker/watcher.ts
+++ b/src/docker/watcher.ts
@@ -15,6 +15,7 @@ export class Watcher {
     private docker: DockerClient,
     private reconciler: Reconciler,
     private resyncSeconds: number,
+    private retryMs = EVENT_STREAM_RETRY_MS,
   ) {}
 
   async start(): Promise<void> {
@@ -33,15 +34,26 @@ export class Watcher {
   }
 
   private async watchEvents(): Promise<void> {
+    let catchUp = false;
     while (!this.abort.signal.aborted) {
       try {
+        if (catchUp) {
+          catchUp = false;
+          await this.reconciler.reconcile();
+        }
         for await (const _ of this.docker.containerEvents(this.abort.signal)) {
           await this.reconciler.reconcile();
         }
       } catch (err) {
         if (this.abort.signal.aborted) return;
-        console.error(`[watcher] event stream lost, retrying in ${EVENT_STREAM_RETRY_MS}ms:`, err);
-        await Bun.sleep(EVENT_STREAM_RETRY_MS);
+        catchUp = true;
+        // Bun's fetch aborts response streams after ~5 idle minutes and the
+        // Docker events endpoint is silent while nothing changes, so a
+        // TimeoutError is routine: resubscribe right away without logging.
+        if (err instanceof Error && err.name === "TimeoutError") continue;
+        const detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+        console.error(`[watcher] event stream lost, retrying in ${this.retryMs}ms: ${detail}`);
+        await Bun.sleep(this.retryMs);
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #7.

Bun's `fetch` aborts response streams after ~5 idle minutes and the Docker `GET /events` endpoint is silent while no container changes state, so the watcher's event stream died with a `TimeoutError` every 5 quiet minutes — dumping the full DOMException (~30 lines) to the log each time and sleeping 5 s before resubscribing.

## Changes

- `TimeoutError` is now treated as a routine reconnect: resubscribe immediately, no retry penalty, no logging.
- Real errors keep the 5 s retry but log a single line (`name: message`) instead of the object dump.
- After any stream drop, a catch-up reconcile runs on resume, closing the blind window that previously waited for the periodic resync.
- New `Watcher` unit tests with a scripted fake `DockerClient` covering both paths (`src/docker/watcher.test.ts`).

## Testing

- `bun test` — 73 pass, 0 fail
- `bun run lint` — clean