### PR TITLE
feat: zero-config Docker socket access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update \
 COPY --from=install /app/node_modules ./node_modules
 COPY package.json ./
 COPY src ./src
+COPY --chmod=755 docker-entrypoint.sh /docker-entrypoint.sh
 
-USER bun
-ENTRYPOINT ["bun", "run", "src/index.ts"]
+# No USER: the entrypoint grants the app user the Docker socket's group
+# (whatever GID the host uses) and drops to it before exec'ing the app.
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["bun", "run", "src/index.ts"]

--- a/README.md
+++ b/README.md
@@ -47,10 +47,8 @@ services:
       CLOUDFLARE_TUNNEL_ID: ${CLOUDFLARE_TUNNEL_ID}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # the image runs as a non-root user; grant it the host's docker group
-    # to read the socket:  stat -c '%g' /var/run/docker.sock
-    group_add:
-      - "990"
+    # No user/group setup needed: the entrypoint detects the socket's group,
+    # grants it to the app user and drops privileges before starting.
 ```
 
 Or start with the zero-credential dry run:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Zero-config Docker socket access: when the container starts as root, grant
+# the app user the group that owns the mounted Docker socket, then drop
+# privileges before exec'ing the app. Started as any other user (compose
+# `user:` override), the script is a no-op passthrough.
+set -eu
+
+SOCK="${DOCKER_SOCK:-/var/run/docker.sock}"
+
+if [ "$(id -u)" = "0" ]; then
+  if [ -S "$SOCK" ]; then
+    sock_gid="$(stat -c '%g' "$SOCK")"
+    exec setpriv --reuid bun --regid bun --groups "$sock_gid" -- "$@"
+  fi
+  exec setpriv --reuid bun --regid bun --clear-groups -- "$@"
+fi
+
+exec "$@"

--- a/src/docker/client.ts
+++ b/src/docker/client.ts
@@ -11,6 +11,12 @@ export class DockerClient {
     return fetch(`http://docker${path}`, { unix: this.sockPath });
   }
 
+  /** Cheap connectivity check against the Engine's /_ping endpoint. */
+  async ping(): Promise<void> {
+    const res = await this.fetch("/_ping");
+    if (!res.ok) throw new Error(`Docker API ${res.status}: ${await res.text()}`);
+  }
+
   async listRunningContainers(): Promise<ContainerInfo[]> {
     const res = await this.fetch("/containers/json");
     if (!res.ok) throw new Error(`Docker API ${res.status}: ${await res.text()}`);

--- a/src/docker/preflight.test.ts
+++ b/src/docker/preflight.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { diagnoseSocketAccess } from "./preflight";
+
+describe("diagnoseSocketAccess", () => {
+  const cleanups: Array<() => Promise<void> | void> = [];
+  afterEach(async () => {
+    while (cleanups.length) await cleanups.pop()?.();
+  });
+
+  async function tempDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "dockroute-preflight-"));
+    cleanups.push(() => rm(dir, { recursive: true, force: true }));
+    return dir;
+  }
+
+  function listen(path: string): void {
+    const server = Bun.listen({ unix: path, socket: { data() {} } });
+    cleanups.push(() => server.stop(true));
+  }
+
+  test("explains how to mount the socket when the path does not exist", async () => {
+    const message = await diagnoseSocketAccess(join(await tempDir(), "missing.sock"));
+
+    expect(message).toContain("not found");
+    expect(message).toContain("-v /var/run/docker.sock");
+  });
+
+  test("flags a non-socket path as a broken bind mount", async () => {
+    const path = join(await tempDir(), "docker.sock");
+    await writeFile(path, "");
+
+    const message = await diagnoseSocketAccess(path);
+
+    expect(message).toContain("not a unix socket");
+  });
+
+  // Root bypasses file permissions, so this diagnosis is untestable as uid 0.
+  test.skipIf(process.getuid?.() === 0)(
+    "explains the group fix when the socket is unreadable",
+    async () => {
+      const path = join(await tempDir(), "docker.sock");
+      listen(path);
+      await chmod(path, 0o000);
+
+      const message = await diagnoseSocketAccess(path);
+
+      expect(message).toContain("Permission denied");
+      expect(message).toContain("group_add");
+    },
+  );
+
+  test("returns null for a readable socket", async () => {
+    const path = join(await tempDir(), "docker.sock");
+    listen(path);
+
+    expect(await diagnoseSocketAccess(path)).toBeNull();
+  });
+});

--- a/src/docker/preflight.ts
+++ b/src/docker/preflight.ts
@@ -1,0 +1,42 @@
+import { constants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+
+/**
+ * Diagnoses why the Docker socket at `sockPath` is unusable and returns an
+ * actionable message, or null when the socket looks fine (so a connection
+ * failure must have another cause). Bun's fetch collapses every unix-socket
+ * connect error into one generic code, hence the filesystem-level diagnosis.
+ */
+export async function diagnoseSocketAccess(sockPath: string): Promise<string | null> {
+  let info: Awaited<ReturnType<typeof stat>>;
+  try {
+    info = await stat(sockPath);
+  } catch {
+    return (
+      `Docker socket not found at ${sockPath}. ` +
+      `Mount it into the container: -v /var/run/docker.sock:/var/run/docker.sock:ro ` +
+      `(or point DOCKER_SOCK at its path).`
+    );
+  }
+
+  if (!info.isSocket()) {
+    return (
+      `${sockPath} exists but is not a unix socket. ` +
+      `This usually means the bind mount source was missing on the host, ` +
+      `so Docker created an empty directory in its place.`
+    );
+  }
+
+  try {
+    await access(sockPath, constants.R_OK | constants.W_OK);
+  } catch {
+    return (
+      `Permission denied reading the Docker socket at ${sockPath} ` +
+      `(owned by gid ${info.gid}). Run the container without a user override ` +
+      `so the entrypoint can drop privileges itself, or add that group ` +
+      `explicitly: group_add: ["${info.gid}"].`
+    );
+  }
+
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from "./config";
 import { Reconciler } from "./core/reconciler";
 import { DockerClient } from "./docker/client";
+import { diagnoseSocketAccess } from "./docker/preflight";
 import { Watcher } from "./docker/watcher";
 import { createProvider } from "./providers/provider";
 import "./providers/log";
@@ -10,6 +11,16 @@ const config = loadConfig();
 console.log(`dockroute starting (provider=${config.provider}, sock=${config.dockerSock})`);
 
 const docker = new DockerClient(config.dockerSock);
+
+try {
+  await docker.ping();
+} catch (err) {
+  const diagnosis = await diagnoseSocketAccess(config.dockerSock);
+  console.error(
+    `[docker] ${diagnosis ?? `Cannot reach the Docker Engine at ${config.dockerSock}: ${err}`}`,
+  );
+  process.exit(1);
+}
 const provider = createProvider(config.provider, config);
 const reconciler = new Reconciler(docker, provider, { defaultTarget: config.defaultTarget });
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,34 @@
+# Store / catalog templates
+
+Deployment templates for community app catalogs. The image they reference is
+`ghcr.io/dockroute/dockroute:latest` (multi-arch: amd64 + arm64), published by
+the release workflow.
+
+## Portainer — `portainer/dockroute.json`
+
+App template in [v3 format](https://docs.portainer.io/advanced/app-templates/format).
+
+- **Self-hosted:** point Portainer's *App Templates URL* at
+  `https://raw.githubusercontent.com/Dockroute/Dockroute/main/templates/portainer/dockroute.json`.
+- **Distribution:** submit the template entry to the
+  [Lissy93/portainer-templates](https://github.com/Lissy93/portainer-templates)
+  aggregator (widely used community source).
+
+## Unraid Community Apps — `unraid/dockroute.xml`
+
+Container template for Unraid's Community Applications plugin.
+
+Submission: CA requires templates to live in a dedicated template repository
+listed with the CA team — copy this file into that repo and follow
+[the CA application process](https://forums.unraid.net/topic/57181-docker-faq/).
+
+## Arcane — `arcane/dockroute/`
+
+Template folder matching the
+[getarcaneapp/templates](https://github.com/getarcaneapp/templates)
+contribution layout (`compose.yaml`, `.env.example`, `template.json`,
+`README.md`).
+
+Submitted upstream: [getarcaneapp/templates#168](https://github.com/getarcaneapp/templates/pull/168).
+Their build generates `registry.json` automatically on merge — never edit it
+by hand. Keep this folder in sync with the upstream copy.

--- a/templates/arcane/dockroute/.env.example
+++ b/templates/arcane/dockroute/.env.example
@@ -1,0 +1,32 @@
+# DNS provider: "log" is a zero-credential dry run that only prints the
+# desired state; switch to "cloudflare" when you are ready.
+DOCKROUTE_PROVIDER=log
+
+# Ownership id written to companion TXT records; lets several DockRoute
+# instances share a zone safely.
+DOCKROUTE_OWNER_ID=default
+
+# sync = create/update/delete owned records; upsert-only = never delete;
+# create-only = never update or delete.
+DOCKROUTE_POLICY=sync
+
+# Fallback record value (IP or CNAME target) when a container omits the
+# dockroute.target label. E.g. your server's LAN or WAN IP.
+DOCKROUTE_DEFAULT_TARGET=
+
+# Optional comma-separated allowlist of DNS zones DockRoute may touch.
+# Empty = all zones the token can see.
+DOCKROUTE_DOMAIN_FILTER=
+
+# Interval of the periodic full reconcile that backs up the event stream.
+DOCKROUTE_RESYNC_SECONDS=60
+
+# Required when DOCKROUTE_PROVIDER=cloudflare.
+# Token permissions: Zone -> DNS -> Edit
+# (+ Account -> Cloudflare Tunnel -> Edit for tunnel publishing).
+CLOUDFLARE_API_TOKEN=
+
+# Only needed for Cloudflare Tunnel publishing (existing tunnel — you keep
+# running cloudflared yourself).
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_TUNNEL_ID=

--- a/templates/arcane/dockroute/README.md
+++ b/templates/arcane/dockroute/README.md
@@ -1,0 +1,33 @@
+# DockRoute
+
+External-DNS for plain Docker hosts — the same idea as Kubernetes
+[external-dns](https://github.com/kubernetes-sigs/external-dns), but for a
+single Docker machine. DockRoute watches your running containers, reads
+`dockroute.*` labels and reconciles the matching DNS records (and Cloudflare
+Tunnel routes) in a pluggable provider.
+
+It **never alters what it cannot prove it manages**: every record it creates
+gets a companion TXT ownership record, and anything without that proof is
+logged and skipped.
+
+## Setup
+
+1. Leave `DOCKROUTE_PROVIDER=log` for a zero-credential dry run, or set it to
+   `cloudflare` and fill in `CLOUDFLARE_API_TOKEN`. Socket permissions are
+   handled automatically — the entrypoint grants the app user the socket's
+   group and drops privileges.
+2. Opt containers in with labels:
+
+```yaml
+services:
+  whoami:
+    image: traefik/whoami
+    labels:
+      dockroute.enabled: "true"
+      dockroute.hostname: "whoami.example.com"
+      # optional — publish through an existing Cloudflare Tunnel:
+      dockroute.tunnel.service: "http://whoami:80"
+```
+
+Full label and configuration reference:
+https://github.com/Dockroute/Dockroute#readme

--- a/templates/arcane/dockroute/compose.yml
+++ b/templates/arcane/dockroute/compose.yml
@@ -1,0 +1,24 @@
+x-arcane:
+  icon: https://github.com/Dockroute.png
+  urls:
+    - https://github.com/Dockroute/Dockroute
+
+services:
+  dockroute:
+    image: ghcr.io/dockroute/dockroute:latest
+    container_name: dockroute
+    restart: unless-stopped
+    environment:
+      DOCKROUTE_PROVIDER: ${DOCKROUTE_PROVIDER:-log}
+      DOCKROUTE_OWNER_ID: ${DOCKROUTE_OWNER_ID:-default}
+      DOCKROUTE_POLICY: ${DOCKROUTE_POLICY:-sync}
+      DOCKROUTE_DEFAULT_TARGET: ${DOCKROUTE_DEFAULT_TARGET:-}
+      DOCKROUTE_DOMAIN_FILTER: ${DOCKROUTE_DOMAIN_FILTER:-}
+      DOCKROUTE_RESYNC_SECONDS: ${DOCKROUTE_RESYNC_SECONDS:-60}
+      CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN:-}
+      CLOUDFLARE_ACCOUNT_ID: ${CLOUDFLARE_ACCOUNT_ID:-}
+      CLOUDFLARE_TUNNEL_ID: ${CLOUDFLARE_TUNNEL_ID:-}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      com.getarcaneapp.arcane.icon: https://github.com/Dockroute.png

--- a/templates/arcane/dockroute/template.json
+++ b/templates/arcane/dockroute/template.json
@@ -1,0 +1,7 @@
+{
+  "name": "DockRoute",
+  "description": "External-DNS for plain Docker hosts — reconciles DNS records and Cloudflare Tunnel routes from container labels.",
+  "version": "1.0.0",
+  "author": "danilodorgam",
+  "tags": ["dns", "networking", "automation", "cloudflare", "docker"]
+}

--- a/templates/portainer/dockroute.json
+++ b/templates/portainer/dockroute.json
@@ -1,0 +1,88 @@
+{
+  "version": "3",
+  "templates": [
+    {
+      "type": 1,
+      "title": "DockRoute",
+      "name": "dockroute",
+      "description": "External-DNS for plain Docker hosts: watches running containers, reads dockroute.* labels and reconciles the matching DNS records — and Cloudflare Tunnel routes — in a pluggable provider. TXT-based ownership means it never alters records it cannot prove it manages.",
+      "categories": ["dns", "networking", "tools"],
+      "platform": "linux",
+      "logo": "https://github.com/Dockroute.png",
+      "image": "ghcr.io/dockroute/dockroute:latest",
+      "restart_policy": "unless-stopped",
+      "note": "Socket permissions are handled automatically: the entrypoint grants the app user the Docker socket's group and drops privileges before starting. Start with the default <code>log</code> provider for a zero-credential dry run, then switch to <code>cloudflare</code>. Opt containers in with labels: <code>dockroute.enabled=true</code> and <code>dockroute.hostname=app.example.com</code>. Docs: https://github.com/Dockroute/Dockroute",
+      "env": [
+        {
+          "name": "DOCKROUTE_PROVIDER",
+          "label": "Provider",
+          "description": "DNS provider. 'log' is a dry run that only prints the desired state.",
+          "default": "log",
+          "select": [
+            { "text": "log (dry run, no credentials)", "value": "log", "default": true },
+            { "text": "cloudflare", "value": "cloudflare" }
+          ]
+        },
+        {
+          "name": "DOCKROUTE_OWNER_ID",
+          "label": "Owner ID",
+          "description": "Ownership id written to companion TXT records; lets several instances share a zone safely.",
+          "default": "default"
+        },
+        {
+          "name": "DOCKROUTE_POLICY",
+          "label": "Sync policy",
+          "description": "sync = create/update/delete owned records; upsert-only = never delete; create-only = never update or delete.",
+          "default": "sync",
+          "select": [
+            { "text": "sync", "value": "sync", "default": true },
+            { "text": "upsert-only", "value": "upsert-only" },
+            { "text": "create-only", "value": "create-only" }
+          ]
+        },
+        {
+          "name": "DOCKROUTE_DEFAULT_TARGET",
+          "label": "Default target",
+          "description": "Fallback record value (IP or CNAME target) when a container omits the dockroute.target label.",
+          "default": ""
+        },
+        {
+          "name": "DOCKROUTE_DOMAIN_FILTER",
+          "label": "Domain filter",
+          "description": "Optional comma-separated allowlist of DNS zones DockRoute may touch. Empty = all zones the token can see.",
+          "default": ""
+        },
+        {
+          "name": "DOCKROUTE_RESYNC_SECONDS",
+          "label": "Resync interval (seconds)",
+          "description": "Interval of the periodic full reconcile that backs up the event stream.",
+          "default": "60"
+        },
+        {
+          "name": "CLOUDFLARE_API_TOKEN",
+          "label": "Cloudflare API token",
+          "description": "Required when provider is cloudflare. Needs Zone → DNS → Edit (+ Account → Cloudflare Tunnel → Edit for tunnel publishing)."
+        },
+        {
+          "name": "CLOUDFLARE_ACCOUNT_ID",
+          "label": "Cloudflare account ID",
+          "description": "Only needed for Cloudflare Tunnel publishing.",
+          "default": ""
+        },
+        {
+          "name": "CLOUDFLARE_TUNNEL_ID",
+          "label": "Cloudflare tunnel ID",
+          "description": "Only needed for Cloudflare Tunnel publishing. Uses an existing tunnel — you keep running cloudflared yourself.",
+          "default": ""
+        }
+      ],
+      "volumes": [
+        {
+          "container": "/var/run/docker.sock",
+          "bind": "/var/run/docker.sock",
+          "readonly": true
+        }
+      ]
+    }
+  ]
+}

--- a/templates/unraid/dockroute.xml
+++ b/templates/unraid/dockroute.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>DockRoute</Name>
+  <Repository>ghcr.io/dockroute/dockroute:latest</Repository>
+  <Registry>https://github.com/Dockroute/Dockroute/pkgs/container/dockroute</Registry>
+  <Network>bridge</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/Dockroute/Dockroute/issues</Support>
+  <Project>https://github.com/Dockroute/Dockroute</Project>
+  <Overview>External-DNS for plain Docker hosts: DockRoute watches your running containers, reads dockroute.* labels and reconciles the matching DNS records - and Cloudflare Tunnel routes - in a pluggable provider.&#xD;
+&#xD;
+Your Docker labels are the source of truth; DockRoute makes the provider match them, and never alters records it cannot prove it manages (ExternalDNS-style TXT ownership).&#xD;
+&#xD;
+Opt a container in with labels: dockroute.enabled=true and dockroute.hostname=app.example.com. Start with the default 'log' provider for a zero-credential dry run, then switch to 'cloudflare'.</Overview>
+  <Category>Network:DNS Tools:Utilities</Category>
+  <Icon>https://github.com/Dockroute.png</Icon>
+  <TemplateURL>https://raw.githubusercontent.com/Dockroute/Dockroute/main/templates/unraid/dockroute.xml</TemplateURL>
+
+  <Config Name="Docker socket" Target="/var/run/docker.sock" Default="/var/run/docker.sock" Mode="ro" Description="Docker Engine socket (read-only). DockRoute only listens to events and lists containers." Type="Path" Display="advanced" Required="true" Mask="false">/var/run/docker.sock</Config>
+  <Config Name="Provider" Target="DOCKROUTE_PROVIDER" Default="log" Mode="" Description="DNS provider: 'log' (dry run, prints desired state, no credentials needed) or 'cloudflare'." Type="Variable" Display="always" Required="true" Mask="false">log</Config>
+  <Config Name="Owner ID" Target="DOCKROUTE_OWNER_ID" Default="default" Mode="" Description="Ownership id written to companion TXT records; lets several DockRoute instances share a zone safely." Type="Variable" Display="always" Required="false" Mask="false">default</Config>
+  <Config Name="Sync policy" Target="DOCKROUTE_POLICY" Default="sync" Mode="" Description="sync = create/update/delete owned records; upsert-only = never delete; create-only = never update or delete." Type="Variable" Display="always" Required="false" Mask="false">sync</Config>
+  <Config Name="Default target" Target="DOCKROUTE_DEFAULT_TARGET" Default="" Mode="" Description="Fallback record value (IP or CNAME target) when a container omits the dockroute.target label. E.g. your server's LAN or WAN IP." Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="Domain filter" Target="DOCKROUTE_DOMAIN_FILTER" Default="" Mode="" Description="Optional comma-separated allowlist of DNS zones DockRoute may touch. Empty = all zones the token can see." Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="Resync interval (seconds)" Target="DOCKROUTE_RESYNC_SECONDS" Default="60" Mode="" Description="Interval of the periodic full reconcile that backs up the event stream." Type="Variable" Display="advanced" Required="false" Mask="false">60</Config>
+  <Config Name="Cloudflare API token" Target="CLOUDFLARE_API_TOKEN" Default="" Mode="" Description="Required when provider is cloudflare. Needs Zone > DNS > Edit (+ Account > Cloudflare Tunnel > Edit for tunnel publishing)." Type="Variable" Display="always" Required="false" Mask="true"/>
+  <Config Name="Cloudflare account ID" Target="CLOUDFLARE_ACCOUNT_ID" Default="" Mode="" Description="Only needed for Cloudflare Tunnel publishing." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Cloudflare tunnel ID" Target="CLOUDFLARE_TUNNEL_ID" Default="" Mode="" Description="Only needed for Cloudflare Tunnel publishing. Uses an existing tunnel - you keep running cloudflared yourself." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+</Container>


### PR DESCRIPTION
Closes #11

## What

Removes the biggest install-friction point: users no longer need to discover their host's Docker socket GID (`991`? `998`? `0`?) and wire it through `group_add`.

- **Self-configuring entrypoint with privilege drop** (`docker-entrypoint.sh`): the image starts as root only long enough to read the mounted socket's GID, grant that group to the `bun` user and `exec setpriv` into the app. The main process runs as non-root. An explicit `user:` override bypasses the entrypoint and behaves exactly as today.
- **Startup preflight** (`src/docker/preflight.ts`): pings `/_ping` before starting the watcher; on failure it diagnoses the socket at filesystem level and exits with an actionable message (socket not mounted / bind-mount created a directory / permission denied with the exact `group_add` fix). Needed because Bun's fetch collapses every unix-socket connect error into one generic `FailedToOpenSocket`.
- **Templates and README simplified**: `DOCKER_SOCK_GID` dropped from the Arcane template, `--group-add=0` dropped from the Unraid XML, Portainer note reduced. (This PR also lands the `templates/` directory itself — store submission artifacts referenced by #11.)

## Validation (on a host whose socket GID is 990)

| Scenario | Result |
| --- | --- |
| `docker run -v /var/run/docker.sock:...:ro` with zero extra flags | ✅ starts, reconciles; `docker top` shows pid 1 as uid 1000 (`bun`), not root |
| `--user bun` without group | ✅ exits 1 with: *Permission denied reading the Docker socket ... (owned by gid 990) ... group_add: ["990"]* |
| `--user bun --group-add 990` | ✅ works as before |

`bun test` (77 pass, incl. new preflight tests), `bun run typecheck`, `bun run lint` all clean; Portainer JSON / Unraid XML / Arcane compose re-validated.