### PR TITLE
chore: prep store templates for catalog submission

### DIFF
--- a/templates/arcane/dockroute/README.md
+++ b/templates/arcane/dockroute/README.md
@@ -29,5 +29,4 @@ services:
       dockroute.tunnel.service: "http://whoami:80"
 ```
 
-Full label and configuration reference:
-https://github.com/Dockroute/Dockroute#readme
+Full label and configuration reference: https://www.dockroute.dev

--- a/templates/arcane/dockroute/compose.yml
+++ b/templates/arcane/dockroute/compose.yml
@@ -1,6 +1,7 @@
 x-arcane:
   icon: https://github.com/Dockroute.png
   urls:
+    - https://www.dockroute.dev
     - https://github.com/Dockroute/Dockroute
 
 services:

--- a/templates/portainer/dockroute.json
+++ b/templates/portainer/dockroute.json
@@ -2,6 +2,7 @@
   "version": "3",
   "templates": [
     {
+      "id": 1,
       "type": 1,
       "title": "DockRoute",
       "name": "dockroute",

--- a/templates/portainer/dockroute.json
+++ b/templates/portainer/dockroute.json
@@ -12,7 +12,7 @@
       "logo": "https://github.com/Dockroute.png",
       "image": "ghcr.io/dockroute/dockroute:latest",
       "restart_policy": "unless-stopped",
-      "note": "Socket permissions are handled automatically: the entrypoint grants the app user the Docker socket's group and drops privileges before starting. Start with the default <code>log</code> provider for a zero-credential dry run, then switch to <code>cloudflare</code>. Opt containers in with labels: <code>dockroute.enabled=true</code> and <code>dockroute.hostname=app.example.com</code>. Docs: https://github.com/Dockroute/Dockroute",
+      "note": "Socket permissions are handled automatically: the entrypoint grants the app user the Docker socket's group and drops privileges before starting. Start with the default <code>log</code> provider for a zero-credential dry run, then switch to <code>cloudflare</code>. Opt containers in with labels: <code>dockroute.enabled=true</code> and <code>dockroute.hostname=app.example.com</code>. Docs: https://www.dockroute.dev — Source: https://github.com/Dockroute/Dockroute",
       "env": [
         {
           "name": "DOCKROUTE_PROVIDER",

--- a/templates/unraid/dockroute.xml
+++ b/templates/unraid/dockroute.xml
@@ -15,7 +15,7 @@ Your Docker labels are the source of truth; DockRoute makes the provider match t
 Opt a container in with labels: dockroute.enabled=true and dockroute.hostname=app.example.com. Start with the default 'log' provider for a zero-credential dry run, then switch to 'cloudflare'.</Overview>
   <Category>Network:DNS Tools:Utilities</Category>
   <Icon>https://github.com/Dockroute.png</Icon>
-  <TemplateURL>https://raw.githubusercontent.com/Dockroute/Dockroute/main/templates/unraid/dockroute.xml</TemplateURL>
+  <TemplateURL>https://raw.githubusercontent.com/Dockroute/unraid-templates/main/dockroute.xml</TemplateURL>
 
   <Config Name="Docker socket" Target="/var/run/docker.sock" Default="/var/run/docker.sock" Mode="ro" Description="Docker Engine socket (read-only). DockRoute only listens to events and lists containers." Type="Path" Display="advanced" Required="true" Mask="false">/var/run/docker.sock</Config>
   <Config Name="Provider" Target="DOCKROUTE_PROVIDER" Default="log" Mode="" Description="DNS provider: 'log' (dry run, prints desired state, no credentials needed) or 'cloudflare'." Type="Variable" Display="always" Required="true" Mask="false">log</Config>

--- a/templates/unraid/dockroute.xml
+++ b/templates/unraid/dockroute.xml
@@ -7,12 +7,14 @@
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
   <Support>https://github.com/Dockroute/Dockroute/issues</Support>
-  <Project>https://github.com/Dockroute/Dockroute</Project>
+  <Project>https://www.dockroute.dev</Project>
   <Overview>External-DNS for plain Docker hosts: DockRoute watches your running containers, reads dockroute.* labels and reconciles the matching DNS records - and Cloudflare Tunnel routes - in a pluggable provider.&#xD;
 &#xD;
 Your Docker labels are the source of truth; DockRoute makes the provider match them, and never alters records it cannot prove it manages (ExternalDNS-style TXT ownership).&#xD;
 &#xD;
-Opt a container in with labels: dockroute.enabled=true and dockroute.hostname=app.example.com. Start with the default 'log' provider for a zero-credential dry run, then switch to 'cloudflare'.</Overview>
+Opt a container in with labels: dockroute.enabled=true and dockroute.hostname=app.example.com. Start with the default 'log' provider for a zero-credential dry run, then switch to 'cloudflare'.&#xD;
+&#xD;
+Docs: https://www.dockroute.dev</Overview>
   <Category>Network:DNS Tools:Utilities</Category>
   <Icon>https://github.com/Dockroute.png</Icon>
   <TemplateURL>https://raw.githubusercontent.com/Dockroute/unraid-templates/main/dockroute.xml</TemplateURL>


### PR DESCRIPTION
Refs #13, #14

- **Portainer** (`templates/portainer/dockroute.json`): adds the `id` field required by [Lissy93/portainer-templates](https://github.com/Lissy93/portainer-templates) `Schema.json` (PortainerAppTemplateV3, `id` is a required integer). Validated locally with ajv against their schema.
- **Unraid** (`templates/unraid/dockroute.xml`): `TemplateURL` now points at the dedicated `Dockroute/unraid-templates` repo that Community Applications will index.

Unblocks the sources.csv PR to the Portainer aggregator — its CI fetches this file from `main`, so this must merge first.