### PR TITLE
feat: Pi-hole provider for intranet-only DNS (split-horizon)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,9 @@ flowchart LR
      pipeline run with zero credentials.
    - `cloudflare` — DNS records + Cloudflare Tunnel ingress routes, with
      TXT-based ownership.
-   - `route53`, `rfc2136`, `pihole`, ... — future.
+   - `pihole` — Pi-hole v6 local DNS for intranet-only hostnames
+     (filter-scoped ownership, see below).
+   - `route53`, `rfc2136`, ... — future.
 
 ## Ownership (TXT registry)
 
@@ -105,6 +107,32 @@ ingress list):
   when it actually changed. The endpoint is last-writer-wins, so DockRoute
   assumes it is the **only automated writer** for the tunnels it manages.
 
+## Pi-hole (filter-scoped ownership)
+
+The `pihole` provider writes **local DNS** entries through the Pi-hole v6
+REST API: A/AAAA records as `"IP hostname"` entries in `dns.hosts`, CNAMEs as
+`"source,target[,ttl]"` entries in `dns.cnameRecords`. Its purpose is
+split-horizon setups — hostnames that must resolve only inside the LAN while
+a second DockRoute instance publishes the rest through a public provider.
+
+Pi-hole local DNS cannot carry TXT records, so the TXT registry does not
+apply. Instead, ownership is scoped by configuration — the same model the
+tunnel ingress uses ("DockRoute assumes it is the only automated writer for
+what it manages"):
+
+- `DOCKROUTE_DOMAIN_FILTER` is **required** (startup error without it).
+- Hostnames matching the filter are treated as exclusively DockRoute-managed;
+  sync policies keep their usual semantics inside that boundary (`sync`
+  deletes orphans there, including manually created entries — documented).
+- Anything outside the filter is never created, updated or deleted.
+- Multi-hostname entries (`ip host1 host2`) are left unmanaged and skipped
+  with a warning, even inside the filter.
+- A/AAAA TTLs are ignored (hosts entries have none); CNAME TTLs are honored.
+- Updates are delete-then-add: Pi-hole config entries are plain strings with
+  no stable id.
+- Auth is a session `sid` from `POST /api/auth` (app password), re-acquired
+  once on 401; tunnel routes are warned about and skipped.
+
 ## Label schema
 
 | Label                        | Required | Default                    | Description                                  |
@@ -140,10 +168,12 @@ services:
 | `DOCKROUTE_OWNER_ID`       | `default`              | Ownership id written into registry TXTs |
 | `DOCKROUTE_POLICY`         | `sync`                 | `sync`, `upsert-only` or `create-only`  |
 | `DOCKROUTE_TXT_PREFIX`     | `_dockroute-`          | Registry TXT name prefix                |
-| `DOCKROUTE_DOMAIN_FILTER`  | —                      | Comma-separated zone allowlist          |
+| `DOCKROUTE_DOMAIN_FILTER`  | —                      | Comma-separated zone allowlist (required for `pihole`) |
 | `CLOUDFLARE_API_TOKEN`     | —                      | Required for `cloudflare`. Scopes: Zone → DNS → Edit; Account → Cloudflare Tunnel → Edit (tunnel only) |
 | `CLOUDFLARE_ACCOUNT_ID`    | —                      | Required for tunnel features            |
 | `CLOUDFLARE_TUNNEL_ID`     | —                      | Required for tunnel features            |
+| `PIHOLE_URL`               | —                      | Required for `pihole`: v6 base URL      |
+| `PIHOLE_PASSWORD`          | —                      | Required for `pihole`: app password     |
 
 ## Source layout
 
@@ -168,6 +198,10 @@ src/
       api.ts            Cloudflare v4 wire client (wire types stay here — ACL)
       cloudflare.ts     provider: zones, planner execution, TTL normalization
       tunnel.ts         pure ingress merge (managed/unmanaged/catch-all)
+    pihole/
+      api.ts            Pi-hole v6 wire client: session auth, dns.hosts,
+                        dns.cnameRecords (wire formats stay here — ACL)
+      pihole.ts         provider: filter-scoped ownership, hosts/CNAME diff
 ```
 
 ## Design decisions

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Your Docker Compose file is the source of truth; dockroute makes the
 provider match it, and **never alters what it cannot prove it manages**
 (ExternalDNS-style TXT ownership).
 
-> Status: MVP + Cloudflare. DNS records, TXT ownership, sync policies and
-> Cloudflare Tunnel routes work end to end. See [ARCHITECTURE.md](ARCHITECTURE.md).
+> Status: MVP + Cloudflare + Pi-hole. DNS records, TXT ownership, sync policies,
+> Cloudflare Tunnel routes and Pi-hole local DNS work end to end.
+> See [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Quick start
 
@@ -75,7 +76,7 @@ DOCKROUTE_DEFAULT_TARGET=192.168.1.10 bun start   # provider=log by default
 | Variable                   | Default                | Description                             |
 | -------------------------- | ---------------------- | --------------------------------------- |
 | `DOCKER_SOCK`              | `/var/run/docker.sock` | Docker Engine socket path               |
-| `DOCKROUTE_PROVIDER`       | `log`                  | `log` (dry-run) or `cloudflare`         |
+| `DOCKROUTE_PROVIDER`       | `log`                  | `log` (dry-run), `cloudflare` or `pihole` |
 | `DOCKROUTE_DEFAULT_TARGET` | —                      | Fallback target when label is omitted   |
 | `DOCKROUTE_RESYNC_SECONDS` | `60`                   | Interval of the periodic full reconcile |
 | `DOCKROUTE_OWNER_ID`       | `default`              | Ownership id — lets several instances share a zone safely |
@@ -85,6 +86,41 @@ DOCKROUTE_DEFAULT_TARGET=192.168.1.10 bun start   # provider=log by default
 | `CLOUDFLARE_API_TOKEN`     | —                      | Token with Zone→DNS→Edit (+ Account→Cloudflare Tunnel→Edit for tunnels) |
 | `CLOUDFLARE_ACCOUNT_ID`    | —                      | For tunnel publishing                   |
 | `CLOUDFLARE_TUNNEL_ID`     | —                      | For tunnel publishing (existing tunnel, you run `cloudflared`) |
+| `PIHOLE_URL`               | —                      | Pi-hole v6 base URL, e.g. `http://192.168.1.5` |
+| `PIHOLE_PASSWORD`          | —                      | Pi-hole app password (Settings → Web interface / API) |
+
+## Pi-hole: intranet-only DNS (split-horizon)
+
+Some services should resolve only inside your LAN. Point a DockRoute
+instance at Pi-hole's local DNS ([v6 API](https://docs.pi-hole.net/api/)):
+
+```yaml
+services:
+  dockroute-lan:
+    image: ghcr.io/dockroute/dockroute:latest
+    environment:
+      DOCKROUTE_PROVIDER: pihole
+      PIHOLE_URL: http://192.168.1.5
+      PIHOLE_PASSWORD: ${PIHOLE_PASSWORD}
+      DOCKROUTE_DOMAIN_FILTER: home.lan   # required for pihole
+      DOCKROUTE_DEFAULT_TARGET: 192.168.1.10
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+```
+
+Containers labeled with a `home.lan` hostname get an A/AAAA hosts entry (or
+CNAME) in Pi-hole; anything outside the filter is skipped. For split-horizon,
+run a second instance with `DOCKROUTE_PROVIDER=cloudflare` for your public
+domain — each instance only touches hostnames matching its own filter.
+
+Pi-hole cannot store TXT records, so the ownership model differs from the
+other providers: `DOCKROUTE_DOMAIN_FILTER` is **required** and DockRoute
+assumes it is the *only* writer for hostnames under the filtered domains —
+manually created entries there will be removed under the default `sync`
+policy. Entries outside the filter (and multi-hostname entries like
+`ip host1 host2`) are never touched. A/AAAA TTLs are ignored (Pi-hole hosts
+entries have none); CNAME TTLs are honored. Tunnel labels are skipped with a
+warning.
 
 ## Safety model
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -41,4 +41,27 @@ describe("loadConfig", () => {
     });
     expect(config.cloudflare).toEqual({ apiToken: "token", accountId: "acc", tunnelId: "tun" });
   });
+
+  test("requires url and password for the pihole provider", () => {
+    expect(() => loadConfig({ DOCKROUTE_PROVIDER: "pihole" })).toThrow(
+      /PIHOLE_URL and PIHOLE_PASSWORD/,
+    );
+  });
+
+  test("requires a domain filter for the pihole provider", () => {
+    expect(() =>
+      loadConfig({
+        DOCKROUTE_PROVIDER: "pihole",
+        PIHOLE_URL: "http://pihole",
+        PIHOLE_PASSWORD: "pw",
+      }),
+    ).toThrow(/DOCKROUTE_DOMAIN_FILTER is required/);
+    const config = loadConfig({
+      DOCKROUTE_PROVIDER: "pihole",
+      PIHOLE_URL: "http://pihole",
+      PIHOLE_PASSWORD: "pw",
+      DOCKROUTE_DOMAIN_FILTER: "home.lan",
+    });
+    expect(config.pihole).toEqual({ url: "http://pihole", password: "pw" });
+  });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,11 @@ export interface CloudflareConfig {
   tunnelId?: string;
 }
 
+export interface PiholeConfig {
+  url?: string;
+  password?: string;
+}
+
 export interface Config {
   dockerSock: string;
   provider: string;
@@ -18,6 +23,7 @@ export interface Config {
   /** Optional allowlist of zones DockRoute may touch. Empty = all. */
   domainFilter: string[];
   cloudflare: CloudflareConfig;
+  pihole: PiholeConfig;
 }
 
 export function loadConfig(env = process.env): Config {
@@ -36,6 +42,29 @@ export function loadConfig(env = process.env): Config {
     throw new Error("CLOUDFLARE_API_TOKEN is required when DOCKROUTE_PROVIDER=cloudflare");
   }
 
+  const domainFilter = (env.DOCKROUTE_DOMAIN_FILTER ?? "")
+    .split(",")
+    .map((d) => d.trim())
+    .filter(Boolean);
+
+  const pihole: PiholeConfig = {
+    url: env.PIHOLE_URL,
+    password: env.PIHOLE_PASSWORD,
+  };
+  if (provider === "pihole") {
+    if (!pihole.url || !pihole.password) {
+      throw new Error("PIHOLE_URL and PIHOLE_PASSWORD are required when DOCKROUTE_PROVIDER=pihole");
+    }
+    if (domainFilter.length === 0) {
+      // Pi-hole local DNS cannot store ownership TXT records, so the domain
+      // filter is the only boundary between managed and hands-off entries.
+      throw new Error(
+        "DOCKROUTE_DOMAIN_FILTER is required when DOCKROUTE_PROVIDER=pihole — " +
+          "it defines the domains DockRoute exclusively manages in Pi-hole",
+      );
+    }
+  }
+
   return {
     dockerSock: env.DOCKER_SOCK ?? "/var/run/docker.sock",
     provider,
@@ -44,10 +73,8 @@ export function loadConfig(env = process.env): Config {
     ownerId: env.DOCKROUTE_OWNER_ID ?? "default",
     policy: policy as Policy,
     txtPrefix: env.DOCKROUTE_TXT_PREFIX ?? "_dockroute-",
-    domainFilter: (env.DOCKROUTE_DOMAIN_FILTER ?? "")
-      .split(",")
-      .map((d) => d.trim())
-      .filter(Boolean),
+    domainFilter,
     cloudflare,
+    pihole,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { Watcher } from "./docker/watcher";
 import { createProvider } from "./providers/provider";
 import "./providers/log";
 import "./providers/cloudflare/cloudflare";
+import "./providers/pihole/pihole";
 
 const config = loadConfig();
 console.log(`dockroute starting (provider=${config.provider}, sock=${config.dockerSock})`);

--- a/src/providers/pihole/api.test.ts
+++ b/src/providers/pihole/api.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { PiholeFetchApi } from "./api";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+interface Call {
+  url: string;
+  method: string;
+  sid: string | null;
+}
+
+const AUTH_OK = { session: { valid: true, sid: "sid-1" } };
+
+function stubFetch(
+  handler: (url: string, init?: RequestInit) => { status?: number; body?: unknown },
+) {
+  const calls: Call[] = [];
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    calls.push({
+      url: u,
+      method: init?.method ?? "GET",
+      sid: new Headers(init?.headers).get("X-FTL-SID") || null,
+    });
+    if (u.endsWith("/api/auth")) return Response.json(AUTH_OK);
+    const { status = 200, body = {} } = handler(u, init);
+    return status === 204 ? new Response(null, { status }) : Response.json(body, { status });
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("PiholeFetchApi", () => {
+  test("authenticates once and sends the session id on requests", async () => {
+    const calls = stubFetch(() => ({ body: { config: { dns: { hosts: ["1.2.3.4 a.lan"] } } } }));
+    const api = new PiholeFetchApi("http://pihole/", "pw");
+
+    const hosts = await api.getHosts();
+    await api.getHosts();
+
+    expect(hosts).toEqual(["1.2.3.4 a.lan"]);
+    expect(calls.map((c) => c.url)).toEqual([
+      "http://pihole/api/auth",
+      "http://pihole/api/config/dns/hosts",
+      "http://pihole/api/config/dns/hosts",
+    ]);
+    expect(calls[1]?.sid).toBe("sid-1");
+  });
+
+  test("re-authenticates and retries once on 401", async () => {
+    let denied = false;
+    const calls = stubFetch(() => {
+      if (!denied) {
+        denied = true;
+        return { status: 401, body: { error: { message: "unauthorized" } } };
+      }
+      return { body: { config: { dns: { hosts: [] } } } };
+    });
+    const api = new PiholeFetchApi("http://pihole", "pw");
+
+    await api.getHosts();
+
+    expect(calls.map((c) => c.method)).toEqual(["POST", "GET", "POST", "GET"]);
+  });
+
+  test("URL-encodes entries and accepts 204 responses", async () => {
+    const calls = stubFetch(() => ({ status: 204 }));
+    const api = new PiholeFetchApi("http://pihole", "pw");
+
+    await api.deleteHost("1.2.3.4 a.lan");
+
+    expect(calls.at(-1)?.url).toBe("http://pihole/api/config/dns/hosts/1.2.3.4%20a.lan");
+    expect(calls.at(-1)?.method).toBe("DELETE");
+  });
+
+  test("adds CNAME entries via the cnameRecords endpoint", async () => {
+    const calls = stubFetch(() => ({ status: 201, body: {} }));
+    const api = new PiholeFetchApi("http://pihole", "pw");
+
+    await api.addCnameRecord("a.lan,b.lan,300");
+
+    expect(calls.at(-1)?.url).toBe("http://pihole/api/config/dns/cnameRecords/a.lan%2Cb.lan%2C300");
+    expect(calls.at(-1)?.method).toBe("PUT");
+  });
+
+  test("surfaces Pi-hole error messages", async () => {
+    stubFetch(() => ({ status: 400, body: { error: { message: "Invalid item" } } }));
+    const api = new PiholeFetchApi("http://pihole", "pw");
+
+    expect(api.addHost("bogus")).rejects.toThrow(/Invalid item/);
+  });
+
+  test("fails fast when authentication is rejected", async () => {
+    globalThis.fetch = (async () =>
+      Response.json(
+        { session: { valid: false, sid: null } },
+        { status: 401 },
+      )) as unknown as typeof fetch;
+    const api = new PiholeFetchApi("http://pihole", "bad");
+
+    expect(api.getHosts()).rejects.toThrow(/PIHOLE_PASSWORD/);
+  });
+});

--- a/src/providers/pihole/api.ts
+++ b/src/providers/pihole/api.ts
@@ -1,0 +1,109 @@
+/**
+ * Thin Pi-hole v6 REST API client (the v5 legacy API is not supported).
+ * All Pi-hole wire shapes live here and in the sibling provider file — they
+ * must never leak into src/core/ (ACL). Exported as an interface so tests
+ * inject an in-memory fake.
+ *
+ * Local A/AAAA records are `"IP hostname"` entries in the `dns.hosts` config
+ * array; CNAMEs are `"source,target[,ttl]"` entries in `dns.cnameRecords`.
+ * Entries are added/removed one at a time via the item endpoints.
+ */
+
+export interface PiholeApi {
+  getHosts(): Promise<string[]>;
+  addHost(entry: string): Promise<void>;
+  deleteHost(entry: string): Promise<void>;
+  getCnameRecords(): Promise<string[]>;
+  addCnameRecord(entry: string): Promise<void>;
+  deleteCnameRecord(entry: string): Promise<void>;
+}
+
+interface PiholeAuthResponse {
+  session?: { valid?: boolean; sid?: string | null };
+}
+
+interface PiholeConfigResponse {
+  config?: { dns?: { hosts?: string[]; cnameRecords?: string[] } };
+}
+
+interface PiholeErrorResponse {
+  error?: { key?: string; message?: string; hint?: string | null };
+}
+
+export class PiholeFetchApi implements PiholeApi {
+  private baseUrl: string;
+  private sid: string | null = null;
+
+  constructor(
+    url: string,
+    private password: string,
+  ) {
+    this.baseUrl = url.replace(/\/+$/, "");
+  }
+
+  async getHosts(): Promise<string[]> {
+    const res = await this.request<PiholeConfigResponse>("/api/config/dns/hosts", "GET");
+    return res.config?.dns?.hosts ?? [];
+  }
+
+  async addHost(entry: string): Promise<void> {
+    await this.request(`/api/config/dns/hosts/${encodeURIComponent(entry)}`, "PUT");
+  }
+
+  async deleteHost(entry: string): Promise<void> {
+    await this.request(`/api/config/dns/hosts/${encodeURIComponent(entry)}`, "DELETE");
+  }
+
+  async getCnameRecords(): Promise<string[]> {
+    const res = await this.request<PiholeConfigResponse>("/api/config/dns/cnameRecords", "GET");
+    return res.config?.dns?.cnameRecords ?? [];
+  }
+
+  async addCnameRecord(entry: string): Promise<void> {
+    await this.request(`/api/config/dns/cnameRecords/${encodeURIComponent(entry)}`, "PUT");
+  }
+
+  async deleteCnameRecord(entry: string): Promise<void> {
+    await this.request(`/api/config/dns/cnameRecords/${encodeURIComponent(entry)}`, "DELETE");
+  }
+
+  private async request<T>(path: string, method: string): Promise<T> {
+    if (!this.sid) await this.authenticate();
+    let res = await this.rawRequest(path, method);
+    if (res.status === 401) {
+      // Session expired — re-authenticate once and retry.
+      await this.authenticate();
+      res = await this.rawRequest(path, method);
+    }
+    if (!res.ok) throw await this.toError(path, method, res);
+    if (res.status === 204) return undefined as T;
+    return (await res.json()) as T;
+  }
+
+  private async rawRequest(path: string, method: string): Promise<Response> {
+    return fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: { "X-FTL-SID": this.sid ?? "" },
+    });
+  }
+
+  private async authenticate(): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/api/auth`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password: this.password }),
+    });
+    const payload = (await res.json().catch(() => null)) as PiholeAuthResponse | null;
+    const sid = payload?.session?.valid ? payload.session.sid : null;
+    if (!res.ok || !sid) {
+      throw new Error(`Pi-hole authentication failed (HTTP ${res.status}) — check PIHOLE_PASSWORD`);
+    }
+    this.sid = sid;
+  }
+
+  private async toError(path: string, method: string, res: Response): Promise<Error> {
+    const payload = (await res.json().catch(() => null)) as PiholeErrorResponse | null;
+    const details = payload?.error?.message ?? `HTTP ${res.status}`;
+    return new Error(`Pi-hole API ${method} ${path} failed — ${details}`);
+  }
+}

--- a/src/providers/pihole/pihole.test.ts
+++ b/src/providers/pihole/pihole.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+import { type Config, loadConfig } from "../../config";
+import type { DesiredState, DnsRecord } from "../../core/types";
+import type { PiholeApi } from "./api";
+import { PiholeProvider } from "./pihole";
+
+class FakePiholeApi implements PiholeApi {
+  hosts: string[] = [];
+  cnames: string[] = [];
+  calls: string[] = [];
+
+  async getHosts(): Promise<string[]> {
+    return [...this.hosts];
+  }
+
+  async addHost(entry: string): Promise<void> {
+    this.calls.push(`addHost:${entry}`);
+    this.hosts.push(entry);
+  }
+
+  async deleteHost(entry: string): Promise<void> {
+    this.calls.push(`deleteHost:${entry}`);
+    this.hosts = this.hosts.filter((h) => h !== entry);
+  }
+
+  async getCnameRecords(): Promise<string[]> {
+    return [...this.cnames];
+  }
+
+  async addCnameRecord(entry: string): Promise<void> {
+    this.calls.push(`addCname:${entry}`);
+    this.cnames.push(entry);
+  }
+
+  async deleteCnameRecord(entry: string): Promise<void> {
+    this.calls.push(`deleteCname:${entry}`);
+    this.cnames = this.cnames.filter((c) => c !== entry);
+  }
+}
+
+function makeConfig(env: Record<string, string> = {}): Config {
+  return loadConfig({
+    DOCKROUTE_PROVIDER: "pihole",
+    PIHOLE_URL: "http://pihole",
+    PIHOLE_PASSWORD: "pw",
+    DOCKROUTE_DOMAIN_FILTER: "home.lan",
+    ...env,
+  });
+}
+
+function record(hostname: string, over: Partial<DnsRecord> = {}): DnsRecord {
+  return { hostname, type: "A", target: "10.0.0.1", ttl: 300, source: "c1", ...over };
+}
+
+function desired(records: DnsRecord[], over: Partial<DesiredState> = {}): DesiredState {
+  return { records, tunnelRoutes: [], ...over };
+}
+
+describe("PiholeProvider — hosts (A/AAAA)", () => {
+  test("creates a hosts entry for a desired A record", async () => {
+    const api = new FakePiholeApi();
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(desired([record("app.home.lan")]));
+
+    expect(api.hosts).toEqual(["10.0.0.1 app.home.lan"]);
+  });
+
+  test("leaves an up-to-date entry untouched", async () => {
+    const api = new FakePiholeApi();
+    api.hosts = ["10.0.0.1 app.home.lan"];
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(desired([record("app.home.lan")]));
+
+    expect(api.calls).toEqual([]);
+  });
+
+  test("replaces the entry when the target IP changed", async () => {
+    const api = new FakePiholeApi();
+    api.hosts = ["10.0.0.9 app.home.lan"];
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(desired([record("app.home.lan", { target: "10.0.0.2" })]));
+
+    expect(api.calls).toEqual([
+      "deleteHost:10.0.0.9 app.home.lan",
+      "addHost:10.0.0.2 app.home.lan",
+    ]);
+  });
+
+  test("A and AAAA entries for the same hostname coexist", async () => {
+    const api = new FakePiholeApi();
+    api.hosts = ["fd00::1 app.home.lan"];
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(
+      desired([
+        record("app.home.lan"),
+        record("app.home.lan", { type: "AAAA", target: "fd00::1" }),
+      ]),
+    );
+
+    expect(api.hosts.sort()).toEqual(["10.0.0.1 app.home.lan", "fd00::1 app.home.lan"]);
+    expect(api.calls).toEqual(["addHost:10.0.0.1 app.home.lan"]);
+  });
+
+  test("skips hostnames outside the domain filter", async () => {
+    const api = new FakePiholeApi();
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(desired([record("app.example.com")]));
+
+    expect(api.calls).toEqual([]);
+  });
+
+  test("deletes orphaned entries inside the filter under sync", async () => {
+    const api = new FakePiholeApi();
+    api.hosts = ["10.0.0.9 gone.home.lan"];
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(desired([]));
+
+    expect(api.hosts).toEqual([]);
+  });
+
+  test("never deletes entries outside the filter", async () => {
+    const api = new FakePiholeApi();
+    api.hosts = ["192.168.1.1 router.example.com"];
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(desired([]));
+
+    expect(api.hosts).toEqual(["192.168.1.1 router.example.com"]);
+  });
+
+  test("keeps orphans under upsert-only", async () => {
+    const api = new FakePiholeApi();
+    api.hosts = ["10.0.0.9 gone.home.lan"];
+    const provider = new PiholeProvider(api, makeConfig({ DOCKROUTE_POLICY: "upsert-only" }));
+
+    await provider.sync(desired([]));
+
+    expect(api.hosts).toEqual(["10.0.0.9 gone.home.lan"]);
+  });
+
+  test("never updates under create-only", async () => {
+    const api = new FakePiholeApi();
+    api.hosts = ["10.0.0.9 app.home.lan"];
+    const provider = new PiholeProvider(api, makeConfig({ DOCKROUTE_POLICY: "create-only" }));
+
+    await provider.sync(desired([record("app.home.lan", { target: "10.0.0.2" })]));
+
+    expect(api.hosts).toEqual(["10.0.0.9 app.home.lan"]);
+  });
+
+  test("leaves multi-hostname entries alone even inside the filter", async () => {
+    const api = new FakePiholeApi();
+    api.hosts = ["10.0.0.9 a.home.lan b.home.lan"];
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(desired([record("a.home.lan")]));
+
+    // The multi-hostname entry is unmanaged: not updated, not deleted; the
+    // desired record is created alongside it.
+    expect(api.hosts).toEqual(["10.0.0.9 a.home.lan b.home.lan", "10.0.0.1 a.home.lan"]);
+  });
+
+  test("keeps syncing after an API failure on one entry", async () => {
+    const api = new FakePiholeApi();
+    api.addHost = async () => {
+      throw new Error("boom");
+    };
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(desired([record("a.home.lan")]));
+    // No throw: the reconcile loop must stay alive.
+  });
+});
+
+describe("PiholeProvider — CNAMEs", () => {
+  test("creates a CNAME entry with TTL", async () => {
+    const api = new FakePiholeApi();
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(
+      desired([record("alias.home.lan", { type: "CNAME", target: "app.home.lan", ttl: 120 })]),
+    );
+
+    expect(api.cnames).toEqual(["alias.home.lan,app.home.lan,120"]);
+  });
+
+  test("leaves an up-to-date CNAME untouched", async () => {
+    const api = new FakePiholeApi();
+    api.cnames = ["alias.home.lan,app.home.lan,300"];
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(
+      desired([record("alias.home.lan", { type: "CNAME", target: "app.home.lan" })]),
+    );
+
+    expect(api.calls).toEqual([]);
+  });
+
+  test("replaces a CNAME whose target changed", async () => {
+    const api = new FakePiholeApi();
+    api.cnames = ["alias.home.lan,old.home.lan,300"];
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(
+      desired([record("alias.home.lan", { type: "CNAME", target: "new.home.lan" })]),
+    );
+
+    expect(api.calls).toEqual([
+      "deleteCname:alias.home.lan,old.home.lan,300",
+      "addCname:alias.home.lan,new.home.lan,300",
+    ]);
+  });
+
+  test("deletes orphaned CNAMEs inside the filter under sync", async () => {
+    const api = new FakePiholeApi();
+    api.cnames = ["gone.home.lan,app.home.lan,300", "keep.example.com,x.example.com"];
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(desired([]));
+
+    expect(api.cnames).toEqual(["keep.example.com,x.example.com"]);
+  });
+});
+
+describe("PiholeProvider — tunnel routes", () => {
+  test("warns and skips tunnel routes without throwing", async () => {
+    const api = new FakePiholeApi();
+    const provider = new PiholeProvider(api, makeConfig());
+
+    await provider.sync(
+      desired([], {
+        tunnelRoutes: [{ hostname: "t.home.lan", service: "http://app:80", source: "c1" }],
+      }),
+    );
+
+    expect(api.calls).toEqual([]);
+  });
+});

--- a/src/providers/pihole/pihole.ts
+++ b/src/providers/pihole/pihole.ts
@@ -1,0 +1,176 @@
+import type { Config } from "../../config";
+import type { DesiredState, DnsRecord } from "../../core/types";
+import { type Provider, registerProvider } from "../provider";
+import { type PiholeApi, PiholeFetchApi } from "./api";
+
+/**
+ * Pi-hole v6 local-DNS provider, for hostnames that must resolve only inside
+ * the LAN (split-horizon: run a second DockRoute instance with a public
+ * provider for everything else).
+ *
+ * Pi-hole cannot store TXT records, so the TXT ownership registry does not
+ * apply. Instead — mirroring the Cloudflare Tunnel ingress model — DockRoute
+ * assumes it is the ONLY writer for hostnames matching DOCKROUTE_DOMAIN_FILTER
+ * (required for this provider) and never touches anything outside the filter.
+ * Sync policies keep their usual semantics within that boundary.
+ *
+ * A/AAAA records ignore TTL (Pi-hole hosts entries have none); CNAMEs honor it.
+ */
+
+interface HostEntry {
+  ip: string;
+  hostname: string;
+  raw: string;
+}
+
+interface CnameEntry {
+  source: string;
+  target: string;
+  ttl?: string;
+  raw: string;
+}
+
+export class PiholeProvider implements Provider {
+  readonly name = "pihole";
+
+  constructor(
+    private api: PiholeApi,
+    private config: Config,
+  ) {}
+
+  async sync(desired: DesiredState): Promise<void> {
+    if (desired.tunnelRoutes.length > 0) {
+      console.warn(
+        `[pihole] ${desired.tunnelRoutes.length} tunnel route(s) requested but the pihole provider does not support tunnels — skipping`,
+      );
+    }
+
+    const hostRecords: DnsRecord[] = [];
+    const cnameRecords: DnsRecord[] = [];
+    for (const record of desired.records) {
+      if (!this.matchesFilter(record.hostname)) {
+        console.warn(`[pihole] ${record.hostname}: outside DOCKROUTE_DOMAIN_FILTER, skipping`);
+        continue;
+      }
+      if (record.type === "CNAME") cnameRecords.push(record);
+      else hostRecords.push(record);
+    }
+
+    try {
+      await this.syncHosts(hostRecords);
+    } catch (err) {
+      console.error("[pihole] hosts sync failed:", err);
+    }
+    try {
+      await this.syncCnames(cnameRecords);
+    } catch (err) {
+      console.error("[pihole] CNAME sync failed:", err);
+    }
+  }
+
+  private async syncHosts(records: DnsRecord[]): Promise<void> {
+    const managed = new Map<string, HostEntry>();
+    for (const raw of await this.api.getHosts()) {
+      const tokens = raw.trim().split(/\s+/);
+      if (tokens.length < 2) continue;
+      const [ip, ...hostnames] = tokens as [string, ...string[]];
+      if (!hostnames.some((h) => this.matchesFilter(h))) continue;
+      if (hostnames.length > 1) {
+        console.warn(`[pihole] "${raw}": multi-hostname entries are not managed — skipping`);
+        continue;
+      }
+      const hostname = hostnames[0] as string;
+      const key = hostKey(ip, hostname);
+      if (!managed.has(key)) managed.set(key, { ip, hostname, raw });
+    }
+
+    const desiredKeys = new Set<string>();
+    for (const want of records) {
+      const key = `${want.type}:${want.hostname}`;
+      desiredKeys.add(key);
+      const entry = `${want.target} ${want.hostname}`;
+      const existing = managed.get(key);
+      if (existing) {
+        if (existing.ip === want.target || this.config.policy === "create-only") continue;
+        await this.apiCall(`update ${want.type} ${want.hostname} -> ${want.target}`, async () => {
+          await this.api.deleteHost(existing.raw);
+          await this.api.addHost(entry);
+        });
+      } else {
+        await this.apiCall(`create ${want.type} ${want.hostname} -> ${want.target}`, () =>
+          this.api.addHost(entry),
+        );
+      }
+    }
+
+    if (this.config.policy !== "sync") return;
+    for (const [key, entry] of managed) {
+      if (desiredKeys.has(key)) continue;
+      await this.apiCall(`delete orphan "${entry.raw}"`, () => this.api.deleteHost(entry.raw));
+    }
+  }
+
+  private async syncCnames(records: DnsRecord[]): Promise<void> {
+    const managed = new Map<string, CnameEntry>();
+    for (const raw of await this.api.getCnameRecords()) {
+      const parts = raw.split(",").map((p) => p.trim());
+      const [source, target, ttl] = parts;
+      if (parts.length < 2 || parts.length > 3 || !source || !target) continue;
+      if (!this.matchesFilter(source)) continue;
+      if (!managed.has(source)) managed.set(source, { source, target, ttl, raw });
+    }
+
+    const desiredSources = new Set<string>();
+    for (const want of records) {
+      desiredSources.add(want.hostname);
+      const entry = `${want.hostname},${want.target},${want.ttl}`;
+      const existing = managed.get(want.hostname);
+      if (existing) {
+        const unchanged = existing.target === want.target && existing.ttl === String(want.ttl);
+        if (unchanged || this.config.policy === "create-only") continue;
+        await this.apiCall(`update CNAME ${want.hostname} -> ${want.target}`, async () => {
+          await this.api.deleteCnameRecord(existing.raw);
+          await this.api.addCnameRecord(entry);
+        });
+      } else {
+        await this.apiCall(`create CNAME ${want.hostname} -> ${want.target}`, () =>
+          this.api.addCnameRecord(entry),
+        );
+      }
+    }
+
+    if (this.config.policy !== "sync") return;
+    for (const [source, entry] of managed) {
+      if (desiredSources.has(source)) continue;
+      await this.apiCall(`delete orphan CNAME "${entry.raw}"`, () =>
+        this.api.deleteCnameRecord(entry.raw),
+      );
+    }
+  }
+
+  private matchesFilter(hostname: string): boolean {
+    return this.config.domainFilter.some((d) => hostname === d || hostname.endsWith(`.${d}`));
+  }
+
+  private async apiCall(what: string, call: () => Promise<void>): Promise<void> {
+    try {
+      await call();
+      console.log(`[pihole] ${what}`);
+    } catch (err) {
+      console.error(`[pihole] ${what} failed:`, err);
+    }
+  }
+}
+
+/** A/AAAA live in the same hosts list; the address family disambiguates. */
+function hostKey(ip: string, hostname: string): string {
+  return `${ip.includes(":") ? "AAAA" : "A"}:${hostname}`;
+}
+
+registerProvider("pihole", (config) => {
+  const { url, password } = config.pihole;
+  if (!url || !password) {
+    throw new Error("PIHOLE_URL and PIHOLE_PASSWORD are required for the pihole provider");
+  }
+  return new PiholeProvider(new PiholeFetchApi(url, password), config);
+});


### PR DESCRIPTION
Closes #19

## What

Adds a `pihole` provider (Pi-hole v6 REST API) so containers can be published as **LAN-only** hostnames — the split-horizon complement to the public Cloudflare provider: run one DockRoute instance per provider, each scoped by its own `DOCKROUTE_DOMAIN_FILTER`.

## How

- `src/providers/pihole/api.ts` — thin v6 wire client (ACL: wire shapes stay here). Session auth via `POST /api/auth` + `X-FTL-SID`, one re-auth retry on 401. A/AAAA as `"IP hostname"` entries in `dns.hosts`, CNAMEs as `"source,target,ttl"` in `dns.cnameRecords`.
- `src/providers/pihole/pihole.ts` — provider with filter-scoped ownership (see below); updates are delete-then-add since entries are plain strings with no id. Tunnel routes warn + skip per the `Provider` contract.
- `src/config.ts` — `PIHOLE_URL` / `PIHOLE_PASSWORD`, with startup validation.

## Ownership model (deviation from the TXT registry)

Pi-hole local DNS cannot carry TXT records, so the registry planner does not apply. Following the Cloudflare Tunnel precedent ("only automated writer for what it manages"):

- `DOCKROUTE_DOMAIN_FILTER` is **required** for this provider — it is the managed/hands-off boundary.
- Inside the filter, sync policies keep their usual semantics (`sync` deletes orphans there — documented loudly in README).
- Outside the filter (and multi-hostname `ip host1 host2` entries) nothing is ever created, updated or deleted.

## Testing

- Contract-style provider tests against a fake `PiholeApi` (create/update/orphan/policies/filter boundaries/A+AAAA coexistence/error resilience).
- `PiholeFetchApi` tests against a stubbed `fetch` (auth flow, 401 retry, URL encoding, 204 handling, error surfacing).
- `bun run typecheck`, `bun run lint`, `bun test`: 101 pass / 0 fail.