### PR TITLE
fix(ci): never cache the Docker release stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           tags: dockroute:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Never cache the release stage: its apt-get upgrade must see new CVE fixes
+          no-cache-filters: release
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@v0.36.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,8 @@ jobs:
           tags: dockroute:release-scan
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Never cache the release stage: its apt-get upgrade must see new CVE fixes
+          no-cache-filters: release
 
       - name: Scan image with Trivy (gate)
         uses: aquasecurity/trivy-action@v0.36.0
@@ -137,3 +139,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Never cache the release stage: its apt-get upgrade must see new CVE fixes
+          no-cache-filters: release


### PR DESCRIPTION
Closes #22

## Problem

`Docker build & scan` fails on every PR and push to `main` with 9 fixable HIGH findings, all CVE-2026-53615 (util-linux, Debian 13). `Dockerfile:10-12` already applies Debian security updates and that step fixes the CVE today — but all three `docker/build-push-action` steps build with `cache-from: type=gha`, so the `apt-get upgrade` layer is restored from a build made before `deb13u1` reached the archive. Trivy scans stale packages.

## Change

`no-cache-filters: release` on all three build steps. The third one matters as much as the other two: `release.yml:140` is the multi-arch push to GHCR, so without it the scanned image would be clean while the published image still came off the stale cache.

## Verification

Verified locally against a freshly pulled `oven/bun:1` (`sha256:e10577f0…`):

| Check | Result |
| --- | --- |
| `no-cache-filters` is a real `build-push-action@v7` input | present in `action.yml` — not a silently ignored key |
| Final image after `docker build --no-cache-filter release` | `libblkid1`, `mount`, `util-linux` at `2.41.5-0+deb13u1`, `login` at `1:4.16.0-2+really2.41.5-0+deb13u1` |
| Second build, cache behaviour | `[install 2/2] RUN bun install` → `CACHED`; `[release 1/5] RUN apt-get update && apt-get upgrade` → rebuilt |
| `bun run lint` / `typecheck` / `bun test` | clean, 77 pass |

Both workflow files parse as valid YAML.

## Note

Pinning the base image by digest would not have fixed this — Debian ships security updates within the same base digest. Still worth doing separately for reproducibility.