### PR TITLE
fix(ci): pin changelog preset and template for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,14 @@ jobs:
         id: semantic
         uses: cycjimmy/semantic-release-action@v6
         with:
+          # Exact pins: the preset reaches @conventional-changelog/template through a
+          # caret range, and 1.4.0 requires conventional-changelog-writer@9, while
+          # semantic-release 25 still bundles writer 8. Unpin once it ships writer@9.
           extra_plugins: |
             @semantic-release/changelog@7
             @semantic-release/git@11
-            conventional-changelog-conventionalcommits@10
+            conventional-changelog-conventionalcommits@10.3.0
+            @conventional-changelog/template@1.3.0
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Closes #24

## Problem

`Release` has failed on every push to `main` since 2026-08-18, at `generateNotes`:

```
Error: Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer …"
    at .../semantic-release-action/v6/node_modules/conventional-changelog-writer/dist/template.js:73:16
```

`semantic-release@25` bundles `@semantic-release/release-notes-generator@14.1.1`, which depends on `conventional-changelog-writer@^8.0.0`. `@conventional-changelog/template@1.4.0`, published 2026-08-18, requires writer 9+. `extra_plugins` asked for `conventional-changelog-conventionalcommits@10`, and the preset reaches the template through a caret range, so the install drifted into the incompatible pair with no change on our side.

Nothing was tagged — the run dies before that and `Publish image to GHCR` is skipped — but `v0.2.0` is now three commits stale, including the `fix:` from #23 that should have cut `0.2.1`.

## Change

Exact pins for both packages, restoring what the last green release (`v0.2.0`, 2026-08-12) resolved. Ranges are what caused this, so ranges are not the fix. The workflow comment records when the pins can be lifted.

## Verification

Resolved each candidate tree against `semantic-release@25.0.9` and called `generateNotes` with the `conventionalcommits` preset:

| Dependency request | Resolved template / writer | `generateNotes` |
| --- | --- | --- |
| `…conventionalcommits@10` (before) | 1.4.0 / 8.4.0 | fails, reproduces CI exactly |
| `…conventionalcommits@10.3.0` | **1.4.0** / 8.4.0 | still fails |
| `…conventionalcommits@10` + `conventional-changelog-writer@9` | 1.4.0 / **8.4.0 nested**, 9.2.1 unused | still fails |
| **this PR** | 1.3.0 / 8.4.0 | succeeds — `## [0.2.1](…compare/v0.2.0...v0.2.1)` |

The two middle rows are the ones worth knowing about, because both look like the obvious fix and neither works. Pinning only the preset leaves its caret range free to float the template to `1.4.0`. Forcing `writer@9` leaves npm free to nest `8.4.0` under `release-notes-generator` to satisfy `^8.0.0`, and the failing path never loads the root copy.

`release.yml` parses as valid YAML.

## Note

This job only runs on `main`, so PR CI cannot prove it. The real check is the `Release` run on the merge commit: it should cut `0.2.1` and let `Publish image to GHCR` run instead of skipping.