### PR TITLE
chore(ci): pin the base image and derive the CI Bun from it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The Dockerfile is the single source of truth for the Bun version, so the
+      # suite runs on the same runtime the published image ships.
+      - name: Resolve Bun version from the Dockerfile
+        id: bun
+        run: |
+          version=$(sed -n 's|^FROM oven/bun:\([^@ ]*\).*|\1|p' Dockerfile | head -1)
+          [ -n "$version" ] || { echo "::error::could not read the Bun version from the Dockerfile"; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ steps.bun.outputs.version }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The Dockerfile is the single source of truth for the Bun version, so the
+      # suite runs on the same runtime the published image ships.
+      - name: Resolve Bun version from the Dockerfile
+        id: bun
+        run: |
+          version=$(sed -n 's|^FROM oven/bun:\([^@ ]*\).*|\1|p' Dockerfile | head -1)
+          [ -n "$version" ] || { echo "::error::could not read the Bun version from the Dockerfile"; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ steps.bun.outputs.version }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1 AS base
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS base
 WORKDIR /app
 
 FROM base AS install


### PR DESCRIPTION
Closes #26

## Problem

Nothing currently broken — this removes the last two floating versions of the kind that caused #22 and #24.

- `ci.yml` and `release.yml` installed `bun-version: latest`, while the image built on `FROM oven/bun:1`. Two independent moving targets, so a green suite said nothing about the runtime we ship. They agreed only by coincidence — both `1.3.14` at the time of writing.
- `.github/dependabot.yml` already declares `package-ecosystem: docker`, but with an unpinned tag there was no digest to bump, so that block did nothing.

## Change

The Dockerfile becomes the single source of truth:

```
FROM oven/bun:1.3.14@sha256:e10577f0…  # tag + manifest-list digest
```

Both workflows read the version back out of it and hand it to `setup-bun`. Dependabot watches that line, so a base image bump now moves CI and the image in the same commit — drift stops being possible rather than being monitored.

The digest is the OCI index, not a per-platform manifest, so the `linux/amd64,linux/arm64` release build still resolves both.

## Verification

| Check | Result |
| --- | --- |
| Version extraction | `sed …` on the pinned line → `1.3.14` |
| Extraction guard | empty result fails the step with `::error::` instead of silently falling back |
| `docker build --no-cache-filter release` | resolves `oven/bun:1.3.14@sha256:e10577f0…`, builds clean |
| Bun inside the built image | `1.3.14`, matching what CI will install |
| `util-linux` in the built image | `2.41.5-0+deb13u1` — #22's fix still applies, release stage still uncached |
| `bun install --frozen-lockfile`, lint, typecheck, `bun test` | clean, 77 pass |

Both workflow files parse as valid YAML.

## Out of scope

`bun run lint` reports one info: `biome.json`'s `$schema` still points at 2.5.7 after the 2.5.8 bump in #21. Pre-existing on `main`, verified against a clean tree, and unrelated to this change — worth its own one-liner.