### PR TITLE
feat(dns): wait out a grace window before deleting DNS records

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,6 +77,37 @@ by the provider-agnostic planner (`src/providers/registry/planner.ts`):
 
 Conflicts (anything not owned) are never touched under any policy.
 
+## Delete grace
+
+Deleting a record is not the inverse of creating one. A create propagates in
+seconds and is self-correcting; a delete leaves a failure (Cloudflare error
+1016, a negative answer cached by every resolver that asked) that outlives the
+event by minutes. Meanwhile a container that is merely restarting drops out of
+`/containers/json` for a few seconds and looks exactly like a container that
+was removed for good.
+
+So deletions, and only deletions, have hysteresis
+(`src/providers/registry/grace.ts`): a record must be continuously absent from
+the desired state for `DOCKROUTE_DELETE_GRACE_SECONDS` (default 60) before the
+plan's delete is executed, and a record that comes back inside the window is
+never deleted at all. A hostname whose CNAME is still serving its window keeps
+its tunnel ingress rule verbatim, so DNS and tunnel never disagree.
+
+Because the window is measured from the first reconcile that *observed* the
+record as an orphan, orphans that are already there at startup are covered too
+— which is the common case of `docker compose up -d` recreating a whole stack
+and starting DockRoute before the app.
+
+The tracker is in memory and per process: losing it on a restart only reopens
+the window, never shortens it. Setting the variable to `0` restores immediate
+deletion.
+
+The trade-off is deliberate and asymmetric. Waiting too long leaves a record
+pointing at an origin that was intentionally removed, which fails softly and
+heals itself; deleting too early is a user-visible outage with a cached
+failure. DockRoute converges on the Docker state either way, bounded by the
+grace window instead of immediately.
+
 ## Cloudflare Tunnel (existing-tunnel model)
 
 DockRoute does **not** create tunnels or move traffic — you create the tunnel
@@ -139,6 +170,7 @@ services:
 | `DOCKROUTE_RESYNC_SECONDS` | `60`                   | Interval of the periodic full reconcile |
 | `DOCKROUTE_OWNER_ID`       | `default`              | Ownership id written into registry TXTs |
 | `DOCKROUTE_POLICY`         | `sync`                 | `sync`, `upsert-only` or `create-only`  |
+| `DOCKROUTE_DELETE_GRACE_SECONDS` | `60`             | Continuous absence required before a delete runs (`0` = immediate) |
 | `DOCKROUTE_TXT_PREFIX`     | `_dockroute-`          | Registry TXT name prefix                |
 | `DOCKROUTE_DOMAIN_FILTER`  | —                      | Comma-separated zone allowlist          |
 | `CLOUDFLARE_API_TOKEN`     | —                      | Required for `cloudflare`. Scopes: Zone → DNS → Edit; Account → Cloudflare Tunnel → Edit (tunnel only) |
@@ -164,6 +196,7 @@ src/
     registry/
       ownership.ts      TXT ownership format + naming (provider-agnostic)
       planner.ts        pure reconciliation planner: policies, conflicts, orphans
+      grace.ts          delete hysteresis: orphans must stay gone before removal
     cloudflare/
       api.ts            Cloudflare v4 wire client (wire types stay here — ACL)
       cloudflare.ts     provider: zones, planner execution, TTL normalization
@@ -175,6 +208,9 @@ src/
 - **Full-state sync, not incremental patches.** Every reconcile recomputes
   the complete desired set from the Docker API and syncs it. Simpler,
   self-healing, and events only decide *when* to reconcile, never *what*.
+- **Destructive operations get hysteresis, constructive ones do not.** The
+  desired state is still recomputed in full every time; the grace window is
+  applied to the *plan*, so convergence is bounded rather than immediate.
 - **Provider owns the diff, planner owns the rules.** The ownership/policy
   logic is provider-agnostic (`src/providers/registry/`); each provider maps
   its wire format at its own boundary and never leaks it into `src/core/`

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ DOCKROUTE_DEFAULT_TARGET=192.168.1.10 bun start   # provider=log by default
 | `DOCKROUTE_RESYNC_SECONDS` | `60`                   | Interval of the periodic full reconcile |
 | `DOCKROUTE_OWNER_ID`       | `default`              | Ownership id — lets several instances share a zone safely |
 | `DOCKROUTE_POLICY`         | `sync`                 | `sync`, `upsert-only` or `create-only`  |
+| `DOCKROUTE_DELETE_GRACE_SECONDS` | `60`             | How long a record must stay gone before it is deleted (`0` = delete at once) |
 | `DOCKROUTE_TXT_PREFIX`     | `_dockroute-`          | Ownership TXT name prefix               |
 | `DOCKROUTE_DOMAIN_FILTER`  | —                      | Comma-separated zone allowlist          |
 | `CLOUDFLARE_API_TOKEN`     | —                      | Token with Zone→DNS→Edit (+ Account→Cloudflare Tunnel→Edit for tunnels) |
@@ -94,6 +95,11 @@ DOCKROUTE_DEFAULT_TARGET=192.168.1.10 bun start   # provider=log by default
   adopted — conflicts are logged and skipped.
 - Orphan cleanup (container gone → records removed) only happens under the
   default `sync` policy and only for records this instance owns.
+- Deletions wait out `DOCKROUTE_DELETE_GRACE_SECONDS` (default 60) of
+  continuous absence, so a container restart does not take the hostname down.
+  Creates and updates stay immediate: they are cheap and self-correcting,
+  while a deleted record leaves a failure cached far beyond the outage.
+  Raise it if your stacks pull images before starting.
 - Tunnel ingress rules that dockroute did not create are preserved verbatim;
   dockroute assumes it is the only automated writer for the tunnels it manages.
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -20,6 +20,12 @@ describe("loadConfig", () => {
     expect(loadConfig({ DOCKROUTE_DELETE_GRACE_SECONDS: "0" }).deleteGraceSeconds).toBe(0);
   });
 
+  test("a blank delete grace means unset, not zero", () => {
+    for (const value of ["", "   "]) {
+      expect(loadConfig({ DOCKROUTE_DELETE_GRACE_SECONDS: value }).deleteGraceSeconds).toBe(60);
+    }
+  });
+
   test("rejects a negative or non-numeric delete grace", () => {
     for (const value of ["-1", "soon"]) {
       expect(() => loadConfig({ DOCKROUTE_DELETE_GRACE_SECONDS: value })).toThrow(

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -11,7 +11,21 @@ describe("loadConfig", () => {
       txtPrefix: "_dockroute-",
       domainFilter: [],
       resyncSeconds: 60,
+      deleteGraceSeconds: 60,
     });
+  });
+
+  test("parses the delete grace, zero included", () => {
+    expect(loadConfig({ DOCKROUTE_DELETE_GRACE_SECONDS: "180" }).deleteGraceSeconds).toBe(180);
+    expect(loadConfig({ DOCKROUTE_DELETE_GRACE_SECONDS: "0" }).deleteGraceSeconds).toBe(0);
+  });
+
+  test("rejects a negative or non-numeric delete grace", () => {
+    for (const value of ["-1", "soon"]) {
+      expect(() => loadConfig({ DOCKROUTE_DELETE_GRACE_SECONDS: value })).toThrow(
+        /Invalid DOCKROUTE_DELETE_GRACE_SECONDS/,
+      );
+    }
   });
 
   test("accepts every valid policy", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,14 +35,6 @@ export function loadConfig(env = process.env): Config {
     throw new Error(`Invalid DOCKROUTE_POLICY "${policy}". Valid values: ${POLICIES.join(", ")}`);
   }
 
-  const rawGrace = env.DOCKROUTE_DELETE_GRACE_SECONDS;
-  const deleteGraceSeconds = Number(rawGrace ?? DEFAULT_DELETE_GRACE_SECONDS);
-  if (!Number.isFinite(deleteGraceSeconds) || deleteGraceSeconds < 0) {
-    throw new Error(
-      `Invalid DOCKROUTE_DELETE_GRACE_SECONDS "${rawGrace}". Expected a number of seconds >= 0.`,
-    );
-  }
-
   const provider = env.DOCKROUTE_PROVIDER ?? "log";
   const cloudflare: CloudflareConfig = {
     apiToken: env.CLOUDFLARE_API_TOKEN,
@@ -60,7 +52,12 @@ export function loadConfig(env = process.env): Config {
     resyncSeconds: Number(env.DOCKROUTE_RESYNC_SECONDS ?? 60),
     ownerId: env.DOCKROUTE_OWNER_ID ?? "default",
     policy: policy as Policy,
-    deleteGraceSeconds,
+    deleteGraceSeconds: secondsFromEnv(
+      "DOCKROUTE_DELETE_GRACE_SECONDS",
+      env.DOCKROUTE_DELETE_GRACE_SECONDS,
+      DEFAULT_DELETE_GRACE_SECONDS,
+      0,
+    ),
     txtPrefix: env.DOCKROUTE_TXT_PREFIX ?? "_dockroute-",
     domainFilter: (env.DOCKROUTE_DOMAIN_FILTER ?? "")
       .split(",")
@@ -68,4 +65,22 @@ export function loadConfig(env = process.env): Config {
       .filter(Boolean),
     cloudflare,
   };
+}
+
+/**
+ * Reads a numeric env var. A blank value means "not set": Portainer and Unraid
+ * submit a cleared optional field as an empty string, and that has to mean the
+ * default, never a fatal error. `min` is inclusive.
+ */
+function secondsFromEnv(
+  name: string,
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+): number {
+  const value = raw?.trim() ? Number(raw) : fallback;
+  if (!Number.isFinite(value) || value < min) {
+    throw new Error(`Invalid ${name} "${raw}". Expected a number of seconds >= ${min}.`);
+  }
+  return value;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 export const POLICIES = ["sync", "upsert-only", "create-only"] as const;
 export type Policy = (typeof POLICIES)[number];
 
+const DEFAULT_DELETE_GRACE_SECONDS = 60;
+
 export interface CloudflareConfig {
   apiToken?: string;
   accountId?: string;
@@ -14,6 +16,13 @@ export interface Config {
   resyncSeconds: number;
   ownerId: string;
   policy: Policy;
+  /**
+   * How long a record must be continuously absent from the desired state
+   * before its deletion is executed. Protects against container restarts,
+   * where deleting the record costs far more than the outage itself.
+   * `0` deletes as soon as the container leaves the running set.
+   */
+  deleteGraceSeconds: number;
   txtPrefix: string;
   /** Optional allowlist of zones DockRoute may touch. Empty = all. */
   domainFilter: string[];
@@ -24,6 +33,14 @@ export function loadConfig(env = process.env): Config {
   const policy = env.DOCKROUTE_POLICY ?? "sync";
   if (!POLICIES.includes(policy as Policy)) {
     throw new Error(`Invalid DOCKROUTE_POLICY "${policy}". Valid values: ${POLICIES.join(", ")}`);
+  }
+
+  const rawGrace = env.DOCKROUTE_DELETE_GRACE_SECONDS;
+  const deleteGraceSeconds = Number(rawGrace ?? DEFAULT_DELETE_GRACE_SECONDS);
+  if (!Number.isFinite(deleteGraceSeconds) || deleteGraceSeconds < 0) {
+    throw new Error(
+      `Invalid DOCKROUTE_DELETE_GRACE_SECONDS "${rawGrace}". Expected a number of seconds >= 0.`,
+    );
   }
 
   const provider = env.DOCKROUTE_PROVIDER ?? "log";
@@ -43,6 +60,7 @@ export function loadConfig(env = process.env): Config {
     resyncSeconds: Number(env.DOCKROUTE_RESYNC_SECONDS ?? 60),
     ownerId: env.DOCKROUTE_OWNER_ID ?? "default",
     policy: policy as Policy,
+    deleteGraceSeconds,
     txtPrefix: env.DOCKROUTE_TXT_PREFIX ?? "_dockroute-",
     domainFilter: (env.DOCKROUTE_DOMAIN_FILTER ?? "")
       .split(",")

--- a/src/providers/cloudflare/cloudflare.test.ts
+++ b/src/providers/cloudflare/cloudflare.test.ts
@@ -368,7 +368,7 @@ describe("CloudflareProvider — delete grace", () => {
     const provider = new CloudflareProvider(
       api,
       makeConfig(graceEnv),
-      new DeleteGrace(60, clock.now),
+      new DeleteGrace(60, "_dockroute-", clock.now),
     );
 
     await provider.sync(desired());
@@ -387,7 +387,7 @@ describe("CloudflareProvider — delete grace", () => {
     const provider = new CloudflareProvider(
       api,
       makeConfig(graceEnv),
-      new DeleteGrace(60, clock.now),
+      new DeleteGrace(60, "_dockroute-", clock.now),
     );
 
     await provider.sync(desired());
@@ -399,7 +399,7 @@ describe("CloudflareProvider — delete grace", () => {
     expect(api.records.get("z1")).toEqual([]);
   });
 
-  test("the stale record of a hostname that moved to a tunnel is not held back", async () => {
+  test("a hostname that moved to a tunnel drops its stale record and TXT at once", async () => {
     const api = new FakeCloudflareApi();
     seedOwned(api, "moving.example.com");
     const provider = new CloudflareProvider(api, makeConfig({ ...tunnelEnv, ...graceEnv }));
@@ -407,7 +407,9 @@ describe("CloudflareProvider — delete grace", () => {
     await provider.sync(desired({ tunnelRoutes: [route("moving.example.com")] }));
 
     expect(api.find("z1", "A", "moving.example.com")).toBeUndefined();
+    expect(api.find("z1", "TXT", "_dockroute-a.moving.example.com")).toBeUndefined();
     expect(api.find("z1", "CNAME", "moving.example.com")?.content).toBe(TUNNEL_DOMAIN);
+    expect(api.find("z1", "TXT", "_dockroute-cname.moving.example.com")).toBeDefined();
   });
 
   test("the ingress rule survives with the deferred CNAME, then goes with it", async () => {
@@ -424,7 +426,7 @@ describe("CloudflareProvider — delete grace", () => {
     const provider = new CloudflareProvider(
       api,
       makeConfig({ ...tunnelEnv, ...graceEnv }),
-      new DeleteGrace(60, clock.now),
+      new DeleteGrace(60, "_dockroute-", clock.now),
     );
 
     await provider.sync(desired());

--- a/src/providers/cloudflare/cloudflare.test.ts
+++ b/src/providers/cloudflare/cloudflare.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { type Config, loadConfig } from "../../config";
 import type { DesiredState, DnsRecord, TunnelRoute } from "../../core/types";
+import { DeleteGrace } from "../registry/grace";
 import { formatOwnershipContent } from "../registry/ownership";
 import type {
   CfDnsRecord,
@@ -70,16 +71,29 @@ class FakeCloudflareApi implements CloudflareApi {
   }
 }
 
+/** Deletes are immediate here; the grace window has its own describe block. */
 function makeConfig(env: Record<string, string> = {}): Config {
   return loadConfig({
     DOCKROUTE_PROVIDER: "cloudflare",
     CLOUDFLARE_API_TOKEN: "token",
     DOCKROUTE_OWNER_ID: "home-lab",
+    DOCKROUTE_DELETE_GRACE_SECONDS: "0",
     ...env,
   });
 }
 
 const tunnelEnv = { CLOUDFLARE_ACCOUNT_ID: "acc-1", CLOUDFLARE_TUNNEL_ID: TUNNEL_ID };
+
+/** Millisecond clock for DeleteGrace, advanced in seconds. */
+function fakeClock(start = 1_700_000_000_000) {
+  let now = start;
+  return {
+    now: () => now,
+    advance: (seconds: number) => {
+      now += seconds * 1000;
+    },
+  };
+}
 
 function record(hostname: string, over: Partial<DnsRecord> = {}): DnsRecord {
   return { hostname, type: "A", target: "10.0.0.1", ttl: 300, source: "c1", ...over };
@@ -330,5 +344,97 @@ describe("CloudflareProvider — tunnel", () => {
 
     expect(api.tunnelConfig.ingress?.[0]?.service).toBe("http://theirs:80");
     expect(api.tunnelPuts).toEqual([]);
+  });
+});
+
+describe("CloudflareProvider — delete grace", () => {
+  const graceEnv = { DOCKROUTE_DELETE_GRACE_SECONDS: "60" };
+
+  test("an orphan is kept while it serves the grace window", async () => {
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "restarting.example.com");
+    const provider = new CloudflareProvider(api, makeConfig(graceEnv));
+
+    await provider.sync(desired());
+
+    expect(api.find("z1", "A", "restarting.example.com")).toBeDefined();
+    expect(api.records.get("z1")).toHaveLength(2);
+  });
+
+  test("an orphan that comes back is never deleted", async () => {
+    const clock = fakeClock();
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "restarting.example.com");
+    const provider = new CloudflareProvider(
+      api,
+      makeConfig(graceEnv),
+      new DeleteGrace(60, clock.now),
+    );
+
+    await provider.sync(desired());
+    clock.advance(30);
+    await provider.sync(desired({ records: [record("restarting.example.com")] }));
+    clock.advance(120);
+    await provider.sync(desired({ records: [record("restarting.example.com")] }));
+
+    expect(api.find("z1", "A", "restarting.example.com")).toBeDefined();
+  });
+
+  test("an orphan absent for the whole window is deleted with its TXT", async () => {
+    const clock = fakeClock();
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "gone.example.com");
+    const provider = new CloudflareProvider(
+      api,
+      makeConfig(graceEnv),
+      new DeleteGrace(60, clock.now),
+    );
+
+    await provider.sync(desired());
+    expect(api.records.get("z1")).toHaveLength(2);
+
+    clock.advance(61);
+    await provider.sync(desired());
+
+    expect(api.records.get("z1")).toEqual([]);
+  });
+
+  test("the stale record of a hostname that moved to a tunnel is not held back", async () => {
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "moving.example.com");
+    const provider = new CloudflareProvider(api, makeConfig({ ...tunnelEnv, ...graceEnv }));
+
+    await provider.sync(desired({ tunnelRoutes: [route("moving.example.com")] }));
+
+    expect(api.find("z1", "A", "moving.example.com")).toBeUndefined();
+    expect(api.find("z1", "CNAME", "moving.example.com")?.content).toBe(TUNNEL_DOMAIN);
+  });
+
+  test("the ingress rule survives with the deferred CNAME, then goes with it", async () => {
+    const clock = fakeClock();
+    const api = new FakeCloudflareApi();
+    seedOwned(api, "gone.example.com", {
+      type: "CNAME",
+      content: TUNNEL_DOMAIN,
+      proxied: true,
+      ttl: 1,
+    });
+    const rule = { hostname: "gone.example.com", service: "http://gone:80" };
+    api.tunnelConfig = { ingress: [rule, CATCH_ALL] };
+    const provider = new CloudflareProvider(
+      api,
+      makeConfig({ ...tunnelEnv, ...graceEnv }),
+      new DeleteGrace(60, clock.now),
+    );
+
+    await provider.sync(desired());
+    expect(api.tunnelConfig?.ingress).toEqual([rule, CATCH_ALL]);
+    expect(api.tunnelPuts).toEqual([]);
+
+    clock.advance(61);
+    await provider.sync(desired());
+
+    expect(api.records.get("z1")).toEqual([]);
+    expect(api.tunnelConfig?.ingress).toEqual([CATCH_ALL]);
   });
 });

--- a/src/providers/cloudflare/cloudflare.ts
+++ b/src/providers/cloudflare/cloudflare.ts
@@ -29,7 +29,7 @@ export class CloudflareProvider implements Provider {
   constructor(
     private api: CloudflareApi,
     private config: Config,
-    private grace: DeleteGrace = new DeleteGrace(config.deleteGraceSeconds),
+    private grace: DeleteGrace = new DeleteGrace(config.deleteGraceSeconds, config.txtPrefix),
   ) {}
 
   async sync(desired: DesiredState): Promise<void> {

--- a/src/providers/cloudflare/cloudflare.ts
+++ b/src/providers/cloudflare/cloudflare.ts
@@ -1,6 +1,7 @@
 import type { Config } from "../../config";
 import type { DesiredState, DnsRecord, TunnelRoute } from "../../core/types";
 import { type Provider, registerProvider } from "../provider";
+import { DeleteGrace } from "../registry/grace";
 import { parseOwnershipContent, parseTxtName } from "../registry/ownership";
 import { type Plan, planChanges, type RegistryRecord } from "../registry/planner";
 import {
@@ -28,6 +29,7 @@ export class CloudflareProvider implements Provider {
   constructor(
     private api: CloudflareApi,
     private config: Config,
+    private grace: DeleteGrace = new DeleteGrace(config.deleteGraceSeconds),
   ) {}
 
   async sync(desired: DesiredState): Promise<void> {
@@ -48,17 +50,23 @@ export class CloudflareProvider implements Provider {
 
     const managedTunnelHostnames = new Set<string>();
     const conflictedHostnames = new Set<string>();
+    const deferredTunnelHostnames = new Set<string>();
 
     for (const zone of zones) {
       try {
         const actual = await this.fetchActual(zone.id);
-        const plan = planChanges({
-          desired: byZone.perZone.get(zone.id) ?? [],
-          actual: actual.map((e) => e.registry),
-          ownerId: this.config.ownerId,
-          txtPrefix: this.config.txtPrefix,
-          policy: this.config.policy,
-        });
+        const desiredInZone = byZone.perZone.get(zone.id) ?? [];
+        const { plan, deferred } = this.grace.apply(
+          planChanges({
+            desired: desiredInZone,
+            actual: actual.map((e) => e.registry),
+            ownerId: this.config.ownerId,
+            txtPrefix: this.config.txtPrefix,
+            policy: this.config.policy,
+          }),
+          zone.id,
+          new Set(desiredInZone.map((r) => r.hostname)),
+        );
         for (const c of plan.conflicts) {
           console.warn(`[cloudflare] conflict on ${c.type} ${c.hostname}: ${c.reason} — skipping`);
           conflictedHostnames.add(c.hostname);
@@ -67,6 +75,11 @@ export class CloudflareProvider implements Provider {
         if (tunnelDomain) {
           for (const h of ownedTunnelHostnames(actual, tunnelDomain, this.config)) {
             managedTunnelHostnames.add(h);
+          }
+          for (const record of deferred) {
+            if (record.type === "CNAME" && record.content === tunnelDomain) {
+              deferredTunnelHostnames.add(record.hostname);
+            }
           }
         }
       } catch (err) {
@@ -81,7 +94,7 @@ export class CloudflareProvider implements Provider {
       // managedTunnelHostnames holds only hostnames PROVEN ours via the TXT
       // registry before this run — a pre-existing ingress rule for a desired
       // hostname we do not own must surface as a conflict, never be replaced.
-      await this.syncTunnelIngress(routes, managedTunnelHostnames);
+      await this.syncTunnelIngress(routes, managedTunnelHostnames, deferredTunnelHostnames);
     }
   }
 
@@ -150,6 +163,7 @@ export class CloudflareProvider implements Provider {
   private async syncTunnelIngress(
     routes: TunnelRoute[],
     managedHostnames: Set<string>,
+    retainHostnames: Set<string>,
   ): Promise<void> {
     const { accountId, tunnelId } = this.config.cloudflare;
     if (!accountId || !tunnelId) return;
@@ -160,6 +174,9 @@ export class CloudflareProvider implements Provider {
         current: config.ingress ?? [],
         desired: routes.map((t) => ({ hostname: t.hostname, service: t.service })),
         managedHostnames,
+        // A hostname whose CNAME deletion is still serving its grace window
+        // keeps its ingress rule, so DNS and tunnel never disagree about it.
+        retainHostnames,
         policy: this.config.policy,
       });
       for (const hostname of merged.conflicts) {

--- a/src/providers/cloudflare/tunnel.test.ts
+++ b/src/providers/cloudflare/tunnel.test.ts
@@ -97,6 +97,20 @@ describe("mergeIngress", () => {
     expect(result.ingress).toEqual([CATCH_ALL]);
   });
 
+  test("sync keeps an orphaned rule whose DNS deletion is still deferred", () => {
+    const current = [
+      { hostname: "restarting.example.com", service: "http://restarting:80" },
+      CATCH_ALL,
+    ];
+    const result = merge({
+      current,
+      managedHostnames: new Set(["restarting.example.com"]),
+      retainHostnames: new Set(["restarting.example.com"]),
+    });
+    expect(result.changed).toBe(false);
+    expect(result.ingress).toEqual(current);
+  });
+
   test("upsert-only keeps orphaned managed rules", () => {
     const current = [{ hostname: "gone.example.com", service: "http://gone:80" }, CATCH_ALL];
     const result = merge({

--- a/src/providers/cloudflare/tunnel.ts
+++ b/src/providers/cloudflare/tunnel.ts
@@ -22,6 +22,12 @@ export interface MergeIngressInput {
   current: CfIngressRule[];
   desired: DesiredIngressRoute[];
   managedHostnames: Set<string>;
+  /**
+   * Managed hostnames that are no longer desired but whose DNS deletion is
+   * still serving its grace window. Their rule is kept verbatim so a restart
+   * never leaves the tunnel and the zone disagreeing about a hostname.
+   */
+  retainHostnames?: Set<string>;
   policy: Policy;
 }
 
@@ -38,6 +44,7 @@ export function mergeIngress({
   current,
   desired,
   managedHostnames,
+  retainHostnames = new Set(),
   policy,
 }: MergeIngressInput): MergeIngressResult {
   const last = current[current.length - 1];
@@ -59,7 +66,7 @@ export function mergeIngress({
     .map((d) => d.hostname);
   const wanted = desired.filter((d) => !unmanagedHostnames.has(d.hostname));
 
-  const managed = mergeManaged(existingManaged, wanted, policy);
+  const managed = mergeManaged(existingManaged, wanted, policy, retainHostnames);
   managed.sort((a, b) => (a.hostname ?? "").localeCompare(b.hostname ?? ""));
 
   if (existingManaged.length === 0 && managed.length === 0) {
@@ -80,6 +87,7 @@ function mergeManaged(
   existing: CfIngressRule[],
   wanted: DesiredIngressRoute[],
   policy: Policy,
+  retainHostnames: Set<string>,
 ): CfIngressRule[] {
   const existingByHostname = new Map(existing.map((r) => [r.hostname, r]));
   // Preserve extra per-rule settings (e.g. originRequest) when updating our rules.
@@ -88,14 +96,14 @@ function mergeManaged(
     hostname: d.hostname,
     service: d.service,
   }));
+  const wantedHostnames = new Set(wanted.map((d) => d.hostname));
+  const orphans = existing.filter((r) => !wantedHostnames.has(r.hostname as string));
 
   switch (policy) {
     case "sync":
-      return updated;
-    case "upsert-only": {
-      const wantedHostnames = new Set(wanted.map((d) => d.hostname));
-      return [...updated, ...existing.filter((r) => !wantedHostnames.has(r.hostname as string))];
-    }
+      return [...updated, ...orphans.filter((r) => retainHostnames.has(r.hostname as string))];
+    case "upsert-only":
+      return [...updated, ...orphans];
     case "create-only":
       return [...existing, ...updated.filter((r) => !existingByHostname.has(r.hostname))];
   }

--- a/src/providers/registry/grace.test.ts
+++ b/src/providers/registry/grace.test.ts
@@ -3,6 +3,7 @@ import { DeleteGrace } from "./grace";
 import type { Plan, RegistryRecord } from "./planner";
 
 const START = 1_700_000_000_000;
+const PREFIX = "_dockroute-";
 
 function rec(hostname: string, over: Partial<RegistryRecord> = {}): RegistryRecord {
   return { hostname, type: "A", content: "10.0.0.1", ttl: 300, ...over };
@@ -26,7 +27,7 @@ const hostnames = (records: RegistryRecord[]) => records.map((r) => r.hostname);
 
 describe("DeleteGrace", () => {
   test("defers a delete the first time the record goes missing", () => {
-    const grace = new DeleteGrace(60, clock().now);
+    const grace = new DeleteGrace(60, PREFIX, clock().now);
     const result = grace.apply(plan([rec("gone.example.com")]), "z1");
 
     expect(result.plan.deletes).toEqual([]);
@@ -35,7 +36,7 @@ describe("DeleteGrace", () => {
 
   test("executes the delete once the window has fully elapsed", () => {
     const time = clock();
-    const grace = new DeleteGrace(60, time.now);
+    const grace = new DeleteGrace(60, PREFIX, time.now);
 
     grace.apply(plan([rec("gone.example.com")]), "z1");
     time.advance(59);
@@ -49,7 +50,7 @@ describe("DeleteGrace", () => {
 
   test("a record that reappears restarts the window from scratch", () => {
     const time = clock();
-    const grace = new DeleteGrace(60, time.now);
+    const grace = new DeleteGrace(60, PREFIX, time.now);
 
     grace.apply(plan([rec("flapping.example.com")]), "z1");
     time.advance(59);
@@ -61,7 +62,7 @@ describe("DeleteGrace", () => {
 
   test("a record and its ownership TXT leave the window together", () => {
     const time = clock();
-    const grace = new DeleteGrace(60, time.now);
+    const grace = new DeleteGrace(60, PREFIX, time.now);
     const orphan = [rec("gone.example.com"), rec("_dockroute-a.gone.example.com", { type: "TXT" })];
 
     expect(grace.apply(plan(orphan), "z1").deferred).toHaveLength(2);
@@ -71,7 +72,7 @@ describe("DeleteGrace", () => {
 
   test("a delete that failed at the provider is retried without a fresh window", () => {
     const time = clock();
-    const grace = new DeleteGrace(60, time.now);
+    const grace = new DeleteGrace(60, PREFIX, time.now);
 
     grace.apply(plan([rec("gone.example.com")]), "z1");
     time.advance(61);
@@ -82,7 +83,7 @@ describe("DeleteGrace", () => {
 
   test("windows are tracked per scope", () => {
     const time = clock();
-    const grace = new DeleteGrace(60, time.now);
+    const grace = new DeleteGrace(60, PREFIX, time.now);
 
     grace.apply(plan([rec("gone.example.com")]), "z1");
     time.advance(61);
@@ -93,7 +94,7 @@ describe("DeleteGrace", () => {
 
   test("pruning one scope leaves the others untouched", () => {
     const time = clock();
-    const grace = new DeleteGrace(60, time.now);
+    const grace = new DeleteGrace(60, PREFIX, time.now);
 
     grace.apply(plan([rec("gone.example.com")]), "z1");
     time.advance(61);
@@ -103,7 +104,7 @@ describe("DeleteGrace", () => {
   });
 
   test("a record whose hostname is still desired is deleted at once", () => {
-    const grace = new DeleteGrace(60, clock().now);
+    const grace = new DeleteGrace(60, PREFIX, clock().now);
     const result = grace.apply(
       plan([rec("switching.example.com")]),
       "z1",
@@ -114,8 +115,26 @@ describe("DeleteGrace", () => {
     expect(result.deferred).toEqual([]);
   });
 
+  test("a companion TXT leaves with the record it tracks, not on its own name", () => {
+    const grace = new DeleteGrace(60, PREFIX, clock().now);
+    const result = grace.apply(
+      plan([
+        rec("switching.example.com"),
+        rec("_dockroute-a.switching.example.com", { type: "TXT" }),
+      ]),
+      "z1",
+      new Set(["switching.example.com"]),
+    );
+
+    expect(hostnames(result.plan.deletes)).toEqual([
+      "switching.example.com",
+      "_dockroute-a.switching.example.com",
+    ]);
+    expect(result.deferred).toEqual([]);
+  });
+
   test("a grace of zero passes the plan straight through", () => {
-    const grace = new DeleteGrace(0, clock().now);
+    const grace = new DeleteGrace(0, PREFIX, clock().now);
     const result = grace.apply(plan([rec("gone.example.com")]), "z1");
 
     expect(hostnames(result.plan.deletes)).toEqual(["gone.example.com"]);
@@ -123,7 +142,7 @@ describe("DeleteGrace", () => {
   });
 
   test("creates, updates and conflicts are never touched", () => {
-    const grace = new DeleteGrace(60, clock().now);
+    const grace = new DeleteGrace(60, PREFIX, clock().now);
     const input: Plan = {
       creates: [rec("new.example.com")],
       updates: [rec("changed.example.com")],

--- a/src/providers/registry/grace.test.ts
+++ b/src/providers/registry/grace.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { DeleteGrace } from "./grace";
+import type { Plan, RegistryRecord } from "./planner";
+
+const START = 1_700_000_000_000;
+
+function rec(hostname: string, over: Partial<RegistryRecord> = {}): RegistryRecord {
+  return { hostname, type: "A", content: "10.0.0.1", ttl: 300, ...over };
+}
+
+function plan(deletes: RegistryRecord[]): Plan {
+  return { creates: [], updates: [], deletes, conflicts: [] };
+}
+
+function clock(start = START) {
+  let now = start;
+  return {
+    now: () => now,
+    advance: (seconds: number) => {
+      now += seconds * 1000;
+    },
+  };
+}
+
+const hostnames = (records: RegistryRecord[]) => records.map((r) => r.hostname);
+
+describe("DeleteGrace", () => {
+  test("defers a delete the first time the record goes missing", () => {
+    const grace = new DeleteGrace(60, clock().now);
+    const result = grace.apply(plan([rec("gone.example.com")]), "z1");
+
+    expect(result.plan.deletes).toEqual([]);
+    expect(hostnames(result.deferred)).toEqual(["gone.example.com"]);
+  });
+
+  test("executes the delete once the window has fully elapsed", () => {
+    const time = clock();
+    const grace = new DeleteGrace(60, time.now);
+
+    grace.apply(plan([rec("gone.example.com")]), "z1");
+    time.advance(59);
+    expect(grace.apply(plan([rec("gone.example.com")]), "z1").plan.deletes).toEqual([]);
+
+    time.advance(1);
+    const result = grace.apply(plan([rec("gone.example.com")]), "z1");
+    expect(hostnames(result.plan.deletes)).toEqual(["gone.example.com"]);
+    expect(result.deferred).toEqual([]);
+  });
+
+  test("a record that reappears restarts the window from scratch", () => {
+    const time = clock();
+    const grace = new DeleteGrace(60, time.now);
+
+    grace.apply(plan([rec("flapping.example.com")]), "z1");
+    time.advance(59);
+    grace.apply(plan([]), "z1"); // back in the desired state: no longer an orphan
+    time.advance(59);
+
+    expect(grace.apply(plan([rec("flapping.example.com")]), "z1").plan.deletes).toEqual([]);
+  });
+
+  test("a record and its ownership TXT leave the window together", () => {
+    const time = clock();
+    const grace = new DeleteGrace(60, time.now);
+    const orphan = [rec("gone.example.com"), rec("_dockroute-a.gone.example.com", { type: "TXT" })];
+
+    expect(grace.apply(plan(orphan), "z1").deferred).toHaveLength(2);
+    time.advance(61);
+    expect(grace.apply(plan(orphan), "z1").plan.deletes).toHaveLength(2);
+  });
+
+  test("a delete that failed at the provider is retried without a fresh window", () => {
+    const time = clock();
+    const grace = new DeleteGrace(60, time.now);
+
+    grace.apply(plan([rec("gone.example.com")]), "z1");
+    time.advance(61);
+    grace.apply(plan([rec("gone.example.com")]), "z1"); // due, but the API call fails
+
+    expect(grace.apply(plan([rec("gone.example.com")]), "z1").plan.deletes).toHaveLength(1);
+  });
+
+  test("windows are tracked per scope", () => {
+    const time = clock();
+    const grace = new DeleteGrace(60, time.now);
+
+    grace.apply(plan([rec("gone.example.com")]), "z1");
+    time.advance(61);
+
+    expect(grace.apply(plan([rec("gone.example.com")]), "z2").plan.deletes).toEqual([]);
+    expect(grace.apply(plan([rec("gone.example.com")]), "z1").plan.deletes).toHaveLength(1);
+  });
+
+  test("pruning one scope leaves the others untouched", () => {
+    const time = clock();
+    const grace = new DeleteGrace(60, time.now);
+
+    grace.apply(plan([rec("gone.example.com")]), "z1");
+    time.advance(61);
+    grace.apply(plan([]), "z2"); // an unrelated zone with nothing to delete
+
+    expect(grace.apply(plan([rec("gone.example.com")]), "z1").plan.deletes).toHaveLength(1);
+  });
+
+  test("a record whose hostname is still desired is deleted at once", () => {
+    const grace = new DeleteGrace(60, clock().now);
+    const result = grace.apply(
+      plan([rec("switching.example.com")]),
+      "z1",
+      new Set(["switching.example.com"]),
+    );
+
+    expect(hostnames(result.plan.deletes)).toEqual(["switching.example.com"]);
+    expect(result.deferred).toEqual([]);
+  });
+
+  test("a grace of zero passes the plan straight through", () => {
+    const grace = new DeleteGrace(0, clock().now);
+    const result = grace.apply(plan([rec("gone.example.com")]), "z1");
+
+    expect(hostnames(result.plan.deletes)).toEqual(["gone.example.com"]);
+    expect(result.deferred).toEqual([]);
+  });
+
+  test("creates, updates and conflicts are never touched", () => {
+    const grace = new DeleteGrace(60, clock().now);
+    const input: Plan = {
+      creates: [rec("new.example.com")],
+      updates: [rec("changed.example.com")],
+      deletes: [rec("gone.example.com")],
+      conflicts: [{ hostname: "theirs.example.com", type: "A", reason: "not ours" }],
+    };
+
+    const { plan: filtered } = grace.apply(input, "z1");
+    expect(filtered.creates).toEqual(input.creates);
+    expect(filtered.updates).toEqual(input.updates);
+    expect(filtered.conflicts).toEqual(input.conflicts);
+  });
+});

--- a/src/providers/registry/grace.ts
+++ b/src/providers/registry/grace.ts
@@ -1,3 +1,4 @@
+import { parseTxtName } from "./ownership";
 import type { Plan, RegistryRecord } from "./planner";
 
 /**
@@ -19,6 +20,7 @@ export class DeleteGrace {
 
   constructor(
     private graceSeconds: number,
+    private txtPrefix: string,
     private now: () => number = Date.now,
   ) {}
 
@@ -45,7 +47,7 @@ export class DeleteGrace {
       // desired is being replaced, not removed (a plain A record becoming a
       // tunnel CNAME, say), and holding its stale record back would only
       // block the replacement.
-      if (desiredHostnames.has(record.hostname)) {
+      if (desiredHostnames.has(this.trackedHostname(record))) {
         due.push(record);
         continue;
       }
@@ -74,6 +76,16 @@ export class DeleteGrace {
 
     this.prune(scope, planned);
     return { plan: { ...plan, deletes: due }, deferred };
+  }
+
+  /**
+   * The hostname a record keeps resolving. For an ownership TXT that is the
+   * data record it tracks, not its own `<prefix><type>.<hostname>` name, so a
+   * record and its companion always leave the window together.
+   */
+  private trackedHostname(record: RegistryRecord): string {
+    if (record.type !== "TXT") return record.hostname;
+    return parseTxtName(record.hostname, this.txtPrefix)?.hostname ?? record.hostname;
   }
 
   private prune(scope: string, planned: Set<string>): void {

--- a/src/providers/registry/grace.ts
+++ b/src/providers/registry/grace.ts
@@ -1,0 +1,89 @@
+import type { Plan, RegistryRecord } from "./planner";
+
+/**
+ * Deletion hysteresis, provider-agnostic.
+ *
+ * A container that restarts leaves the desired state for a few seconds, and
+ * deleting its record in that window costs far more than the outage itself:
+ * the resulting failure is cached at the DNS edge and by resolvers long after
+ * the container is back. Creates and updates are cheap and self-correcting,
+ * deletes are not, so only deletes wait: a record must be absent from the
+ * desired state for the whole grace window before it is really removed, and
+ * a record that reappears in the meantime is never deleted at all.
+ *
+ * The state is per-process and in-memory. Losing it on a DockRoute restart
+ * only reopens the window, which is the safe direction.
+ */
+export class DeleteGrace {
+  private missingSince = new Map<string, number>();
+
+  constructor(
+    private graceSeconds: number,
+    private now: () => number = Date.now,
+  ) {}
+
+  /**
+   * Splits a plan's deletes into those that have waited out the grace window
+   * and those still serving it. `scope` namespaces the tracked keys (the zone
+   * id for Cloudflare); every key in that scope missing from this plan is
+   * pruned, so a record that came back forgets its timer.
+   */
+  apply(
+    plan: Plan,
+    scope: string,
+    desiredHostnames: Set<string> = new Set(),
+  ): { plan: Plan; deferred: RegistryRecord[] } {
+    if (this.graceSeconds <= 0) return { plan, deferred: [] };
+
+    const now = this.now();
+    const due: RegistryRecord[] = [];
+    const deferred: RegistryRecord[] = [];
+    const planned = new Set<string>();
+
+    for (const record of plan.deletes) {
+      // The window exists to keep a hostname resolving. One that is still
+      // desired is being replaced, not removed (a plain A record becoming a
+      // tunnel CNAME, say), and holding its stale record back would only
+      // block the replacement.
+      if (desiredHostnames.has(record.hostname)) {
+        due.push(record);
+        continue;
+      }
+
+      const key = keyFor(scope, record);
+      planned.add(key);
+      // A key kept after expiry lets a delete that failed at the provider be
+      // retried on the next reconcile instead of serving a fresh window.
+      const since = this.missingSince.get(key) ?? now;
+      this.missingSince.set(key, since);
+
+      const remaining = this.graceSeconds - (now - since) / 1000;
+      if (remaining <= 0) {
+        due.push(record);
+        continue;
+      }
+      deferred.push(record);
+      // The companion TXT rides the same window; logging it too is noise.
+      if (record.type !== "TXT") {
+        console.log(
+          `[grace] ${record.type} ${record.hostname}: pending deletion, ` +
+            `${Math.ceil(remaining)}s remaining`,
+        );
+      }
+    }
+
+    this.prune(scope, planned);
+    return { plan: { ...plan, deletes: due }, deferred };
+  }
+
+  private prune(scope: string, planned: Set<string>): void {
+    const prefix = `${scope}|`;
+    for (const key of this.missingSince.keys()) {
+      if (key.startsWith(prefix) && !planned.has(key)) this.missingSince.delete(key);
+    }
+  }
+}
+
+function keyFor(scope: string, record: RegistryRecord): string {
+  return `${scope}|${record.type}:${record.hostname}`;
+}


### PR DESCRIPTION
Closes #28.

## Why

A container that restarts drops out of `/containers/json` for a few seconds and looks exactly like one that was removed for good, so the `sync` policy deleted its record, its ownership TXT and its tunnel ingress rule on the spot. The hostname then served Cloudflare **error 1016** long after the container was back, because the failure is cached at the edge and the negative answer is cached by resolvers. DockRoute was causing the downtime it exists to avoid.

The two operations are not symmetric. A create propagates in seconds and is self-correcting; a delete leaves a cached failure that outlives the event by minutes. So deletions, and only deletions, get hysteresis.

## What changed

- **`src/providers/registry/grace.ts` (new)**: `DeleteGrace`, provider-agnostic, with an injectable clock. A record must be continuously absent from the desired state for `DOCKROUTE_DELETE_GRACE_SECONDS` before its delete is executed; one that reappears inside the window is never deleted at all. Creates, updates and conflicts pass through untouched.
- **`src/config.ts`**: `DOCKROUTE_DELETE_GRACE_SECONDS`, default `60`, rejecting negative and non-numeric values. A blank value means unset and falls back to the default, via the shared `secondsFromEnv()` helper. `0` restores the previous behavior exactly.
- **`src/providers/cloudflare/cloudflare.ts`**: applies the window per zone and forwards deferred tunnel hostnames to the ingress merge.
- **`src/providers/cloudflare/tunnel.ts`**: `retainHostnames` keeps the ingress rule of a hostname whose CNAME is still serving its window, so DNS and tunnel never disagree. `mergeManaged` now computes `orphans` once for all three policies.
- **README / ARCHITECTURE.md**: the variable in both tables, plus a "Delete grace" section covering the trade-off.

## Design notes

**Applied to the plan, not to the desired state.** Holding stale desired entries would not cover orphans that are already there when DockRoute starts, which is the common case: `docker compose up -d` recreating a stack brings DockRoute up before the app, and it deletes the record on its very first reconcile. Filtering the plan covers both paths with one mechanism.

**A hostname that is still desired skips the window.** Otherwise this would introduce a fresh regression: moving a service from a plain A record to `dockroute.tunnel.service` would hold the stale A for 60s and block the CNAME. A hostname still in the desired state is being replaced, not removed, so there is no outage to protect against.

**The tracked key survives expiry.** If the provider's DELETE fails, the next reconcile retries immediately instead of serving a fresh window. Without this a transient API error would postpone cleanup indefinitely.

**No new state to lose.** The tracker is in memory and per process. A DockRoute restart only reopens the window, never shortens it.

## Effect on the project's premises

- *Never alters what it cannot prove it manages*: strengthened. It adds a temporal axis to the same rule, never delete on evidence younger than N seconds.
- *Full-state sync*: unchanged, the desired state is still recomputed in full every reconcile.
- *No database, stateless container*: unchanged, nothing is persisted.
- *Docker is the source of truth*: convergence goes from immediate to bounded by the window. This one really changes, and it is documented in ARCHITECTURE.md rather than left implicit.

## Testing

`bun test`: 95 pass, 0 fail. `bunx tsc --noEmit` and `bun run lint` clean.

New coverage: the window deferring, resetting on reappearance, expiring, being tracked per zone, surviving a failed delete, and being bypassed for a still-desired hostname; the ingress rule surviving with its deferred CNAME and going away with it; config parsing and validation. Existing provider tests run with the grace at `0`, since they assert the plan and execution path.

## Out of scope

`execute()` runs creates before deletes, so switching a hostname's record *type* (A to CNAME) still fails on the first pass, because Cloudflare refuses a CNAME coexisting with an A record. This predates the change and converges on the next reconcile; reversing the order would open a window with no record at all, which is what this PR is about closing. Worth its own issue.

`templates/` (portainer, unraid, arcane) expose `DOCKROUTE_POLICY` and friends but not the new variable. The default covers every template unchanged, so this is a follow-up rather than a gap.

## Review follow-ups

Applied after the review above:

- **A record and its ownership TXT now leave the window together.** The TXT was matched against the desired hostnames under its own `_dockroute-<type>.<hostname>` name, which is never desired, so a hostname changing record type released the data record at once and held its registry entry for the full window. A TXT is now judged by the hostname it tracks (`5082645`).
- **A blank `DOCKROUTE_DELETE_GRACE_SECONDS` no longer disables the grace.** `Number("") === 0` passed the `>= 0` check and silently turned the feature off. Introduces `secondsFromEnv()`, the helper from #39, which #37 adopts for `DOCKROUTE_RESYNC_SECONDS` (`2677246`).
- **Retitled `fix(core)` to `feat(dns)`**: this adds a user-facing environment variable and changes the default deletion behavior, so it belongs under Features and deserves a minor bump. The scope was also wrong, the code lives in `providers/registry` and `providers/cloudflare`.

Part of #39.
