### PR TITLE
fix(config): validate the resync interval

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -50,8 +50,14 @@ describe("loadConfig", () => {
     expect(loadConfig({ DOCKROUTE_RESYNC_SECONDS: "30" }).resyncSeconds).toBe(30);
   });
 
+  test("a blank resync interval means unset", () => {
+    for (const value of ["", "   "]) {
+      expect(loadConfig({ DOCKROUTE_RESYNC_SECONDS: value }).resyncSeconds).toBe(60);
+    }
+  });
+
   test("rejects invalid resync intervals", () => {
-    for (const value of ["60s", "", "0", "-1"]) {
+    for (const value of ["60s", "0", "-1", "0.5"]) {
       expect(() => loadConfig({ DOCKROUTE_RESYNC_SECONDS: value })).toThrow(
         /Invalid DOCKROUTE_RESYNC_SECONDS/,
       );

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -26,6 +26,18 @@ describe("loadConfig", () => {
     );
   });
 
+  test("parses a valid resync interval", () => {
+    expect(loadConfig({ DOCKROUTE_RESYNC_SECONDS: "30" }).resyncSeconds).toBe(30);
+  });
+
+  test("rejects invalid resync intervals", () => {
+    for (const value of ["60s", "", "0", "-1"]) {
+      expect(() => loadConfig({ DOCKROUTE_RESYNC_SECONDS: value })).toThrow(
+        /Invalid DOCKROUTE_RESYNC_SECONDS/,
+      );
+    }
+  });
+
   test("parses the domain filter as a trimmed list", () => {
     const config = loadConfig({ DOCKROUTE_DOMAIN_FILTER: "example.com, example.org ," });
     expect(config.domainFilter).toEqual(["example.com", "example.org"]);

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,11 +36,19 @@ export function loadConfig(env = process.env): Config {
     throw new Error("CLOUDFLARE_API_TOKEN is required when DOCKROUTE_PROVIDER=cloudflare");
   }
 
+  const resyncSecondsRaw = env.DOCKROUTE_RESYNC_SECONDS;
+  const resyncSeconds = Number(resyncSecondsRaw ?? 60);
+  if (!Number.isFinite(resyncSeconds) || resyncSeconds <= 0) {
+    throw new Error(
+      `Invalid DOCKROUTE_RESYNC_SECONDS "${resyncSecondsRaw}". Expected a number of seconds > 0.`,
+    );
+  }
+
   return {
     dockerSock: env.DOCKER_SOCK ?? "/var/run/docker.sock",
     provider,
     defaultTarget: env.DOCKROUTE_DEFAULT_TARGET,
-    resyncSeconds: Number(env.DOCKROUTE_RESYNC_SECONDS ?? 60),
+    resyncSeconds,
     ownerId: env.DOCKROUTE_OWNER_ID ?? "default",
     policy: policy as Policy,
     txtPrefix: env.DOCKROUTE_TXT_PREFIX ?? "_dockroute-",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 export const POLICIES = ["sync", "upsert-only", "create-only"] as const;
 export type Policy = (typeof POLICIES)[number];
 
+const DEFAULT_RESYNC_SECONDS = 60;
 const DEFAULT_DELETE_GRACE_SECONDS = 60;
 
 export interface CloudflareConfig {
@@ -45,19 +46,16 @@ export function loadConfig(env = process.env): Config {
     throw new Error("CLOUDFLARE_API_TOKEN is required when DOCKROUTE_PROVIDER=cloudflare");
   }
 
-  const resyncSecondsRaw = env.DOCKROUTE_RESYNC_SECONDS;
-  const resyncSeconds = Number(resyncSecondsRaw ?? 60);
-  if (!Number.isFinite(resyncSeconds) || resyncSeconds <= 0) {
-    throw new Error(
-      `Invalid DOCKROUTE_RESYNC_SECONDS "${resyncSecondsRaw}". Expected a number of seconds > 0.`,
-    );
-  }
-
   return {
     dockerSock: env.DOCKER_SOCK ?? "/var/run/docker.sock",
     provider,
     defaultTarget: env.DOCKROUTE_DEFAULT_TARGET,
-    resyncSeconds,
+    resyncSeconds: secondsFromEnv(
+      "DOCKROUTE_RESYNC_SECONDS",
+      env.DOCKROUTE_RESYNC_SECONDS,
+      DEFAULT_RESYNC_SECONDS,
+      1,
+    ),
     ownerId: env.DOCKROUTE_OWNER_ID ?? "default",
     policy: policy as Policy,
     deleteGraceSeconds: secondsFromEnv(


### PR DESCRIPTION
Reject invalid `DOCKROUTE_RESYNC_SECONDS` values at startup instead of letting them become a hot reconcile loop.

Adds coverage for a valid interval and the invalid values from #30.

Closes #30

Tests: `bun test`, `bun run typecheck`, `bun run lint`.

Also closes #39: with the resync interval moved onto `secondsFromEnv()`, both numeric variables now share the helper and treat a blank value as unset.
