### PR TITLE
fix(labels): warn on invalid TTL values

### DIFF
--- a/src/core/labels.test.ts
+++ b/src/core/labels.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { desiredFromContainer } from "./labels";
 import type { ContainerInfo } from "./types";
 
@@ -9,6 +9,13 @@ function container(labels: Record<string, string>): ContainerInfo {
 const empty = { records: [], tunnelRoutes: [] };
 
 describe("desiredFromContainer", () => {
+  let warnSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    warnSpy?.mockRestore();
+    warnSpy = undefined;
+  });
+
   test("ignores containers without dockroute.enabled", () => {
     expect(desiredFromContainer(container({}))).toEqual(empty);
     expect(desiredFromContainer(container({ "dockroute.hostname": "a.example.com" }))).toEqual(
@@ -17,6 +24,7 @@ describe("desiredFromContainer", () => {
   });
 
   test("builds an A record with defaults", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     const { records } = desiredFromContainer(
       container({ "dockroute.enabled": "true", "dockroute.hostname": "a.example.com" }),
       { defaultTarget: "192.168.1.10" },
@@ -30,6 +38,7 @@ describe("desiredFromContainer", () => {
         source: "abc123def4567890",
       },
     ]);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("supports multiple comma-separated hostnames", () => {
@@ -54,6 +63,22 @@ describe("desiredFromContainer", () => {
       }),
     ).records;
     expect(record).toMatchObject({ type: "CNAME", target: "origin.example.com", ttl: 60 });
+  });
+
+  test("warns and uses the default when an explicit ttl is invalid", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const [record] = desiredFromContainer(
+      container({
+        "dockroute.enabled": "true",
+        "dockroute.hostname": "a.example.com",
+        "dockroute.target": "10.0.0.1",
+        "dockroute.ttl": "5m",
+      }),
+    ).records;
+
+    expect(record?.ttl).toBe(300);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith('[labels] /whoami: invalid dockroute.ttl "5m", using 300');
   });
 
   test("skips when no target is resolvable or type is unsupported", () => {

--- a/src/core/labels.ts
+++ b/src/core/labels.ts
@@ -94,14 +94,19 @@ function dnsState(
     return emptyDesiredState();
   }
 
-  const ttl = Number(labels[`${PREFIX}ttl`] ?? DEFAULT_TTL);
+  const rawTtl = labels[`${PREFIX}ttl`];
+  const parsedTtl = Number(rawTtl ?? DEFAULT_TTL);
+  const ttl = Number.isFinite(parsedTtl) && parsedTtl > 0 ? parsedTtl : DEFAULT_TTL;
+  if (rawTtl !== undefined && ttl !== parsedTtl) {
+    console.warn(`[labels] ${name}: invalid dockroute.ttl "${rawTtl}", using ${DEFAULT_TTL}`);
+  }
   const providerSpecific = providerHints(labels);
 
   const records: DnsRecord[] = hostnames.map((hostname) => ({
     hostname,
     type: rawType as RecordType,
     target,
-    ttl: Number.isFinite(ttl) && ttl > 0 ? ttl : DEFAULT_TTL,
+    ttl,
     source: container.Id,
     ...(providerSpecific ? { providerSpecific } : {}),
   }));


### PR DESCRIPTION
## What & why

An explicit invalid `dockroute.ttl` was silently replaced with the default, unlike the other label-misconfiguration paths. This change warns once with the container name, raw value, and fallback while preserving record creation.

Closes #31

## Checklist

- [x] Focused label tests (10/10), `bun run typecheck`, and `bun run lint` pass locally
- [x] Tests cover both invalid and absent TTL labels
- [x] Ownership/conflict safety rules are unaffected
- [x] Docs are unchanged because label semantics and configuration are unchanged

Full `bun test`: 76 passed; two unrelated Unix-socket preflight tests fail on native Windows because `Bun.listen({ unix: path })` does not create the expected filesystem socket there.