### PR TITLE
feat(labels): validate DNS record targets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -143,7 +143,7 @@ ingress list):
 | `dockroute.enabled`          | yes      | —                          | `true` opts the container in                 |
 | `dockroute.hostname`         | yes      | —                          | FQDN(s), comma-separated                     |
 | `dockroute.type`             | no       | `A`                        | `A`, `AAAA` or `CNAME`                       |
-| `dockroute.target`           | no       | `DOCKROUTE_DEFAULT_TARGET` | Record value (IP or CNAME target)            |
+| `dockroute.target`           | no       | `DOCKROUTE_DEFAULT_TARGET` | Record value; must match `dockroute.type` (IPv4 / IPv6 / hostname) |
 | `dockroute.ttl`              | no       | `300`                      | Record TTL in seconds                        |
 | `dockroute.tunnel.service`   | no       | —                          | Origin URL (`http://svc:port`); switches the container to tunnel publishing |
 | `dockroute.cloudflare.proxied` | no     | `false`                    | Serve plain records through Cloudflare's proxy |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ DOCKROUTE_DEFAULT_TARGET=192.168.1.10 bun start   # provider=log by default
 | `dockroute.enabled`            | yes      | —                          | `true` opts the container in      |
 | `dockroute.hostname`           | yes      | —                          | FQDN(s), comma-separated          |
 | `dockroute.type`               | no       | `A`                        | `A`, `AAAA` or `CNAME`            |
-| `dockroute.target`             | no       | `DOCKROUTE_DEFAULT_TARGET` | Record value (IP or CNAME target) |
+| `dockroute.target`             | no       | `DOCKROUTE_DEFAULT_TARGET` | Record value; must match `dockroute.type` (IPv4 / IPv6 / hostname) |
 | `dockroute.ttl`                | no       | `300`                      | TTL in seconds                    |
 | `dockroute.tunnel.service`     | no       | —                          | Origin URL; publish via Cloudflare Tunnel instead of a plain record |
 | `dockroute.cloudflare.proxied` | no       | `false`                    | Proxy plain records through Cloudflare |
@@ -116,6 +116,7 @@ below, fix that entry, and the next reconcile will try it again.
 | `[labels] <container>: invalid dockroute.tunnel.service "<service>" (expected http://, https://, tcp://, ssh://), skipping` | The tunnel origin is not a valid URL with a supported scheme. | Set `dockroute.tunnel.service` to a complete `http://`, `https://`, `tcp://` or `ssh://` URL. |
 | `[labels] <container>: unsupported record type "<type>", skipping` | `dockroute.type` is not supported. | Set it to `A`, `AAAA` or `CNAME`. |
 | `[labels] <container>: no dockroute.target and no default target, skipping` | A plain DNS record has no target. | Add `dockroute.target` or set `DOCKROUTE_DEFAULT_TARGET`. |
+| `[labels] <container>: dockroute.target "<target>" is not a valid <requirement>, skipping` | The target does not match `dockroute.type`: `A` needs an IPv4 address, `AAAA` an IPv6 address, and `CNAME` a hostname rather than an IP. | Correct `dockroute.target`, or `DOCKROUTE_DEFAULT_TARGET` when the container inherits it, or set `dockroute.type` to the type that matches the value. |
 | `[labels] <container>: invalid dockroute.ttl "<ttl>", using 300` | The TTL is not a positive number, so DockRoute falls back to 300 seconds. | Set `dockroute.ttl` to a positive numeric value, or omit it to use the default. |
 | `[reconciler] duplicate desired entry <type>:<hostname>: first container wins, skipping entry from <source>` | More than one container claims the same hostname and record type. | Keep that claim on one container only; the first container in the reconcile wins. |
 | `[reconciler] duplicate hostname <hostname>: already published via tunnel, skipping <type> record from <source>` | The same hostname is requested as both a tunnel route and a plain DNS record. | Choose one publication method and remove the duplicate claim; the tunnel route wins the reconcile. |

--- a/src/core/labels.test.ts
+++ b/src/core/labels.test.ts
@@ -90,9 +90,8 @@ describe("desiredFromContainer", () => {
     for (const [type, target, expected] of [
       ["A", "2001:db8::1", "IPv4 address for an A record"],
       ["AAAA", "192.0.2.1", "IPv6 address for an AAAA record"],
-      ["CNAME", "192.0.2.1", "hostname for a CNAME record"],
-      ["CNAME", "2001:db8::1", "hostname for a CNAME record"],
-      ["CNAME", "   ", "hostname for a CNAME record"],
+      ["CNAME", "192.0.2.1", "hostname for a CNAME record (use an A or AAAA record for an IP)"],
+      ["CNAME", "2001:db8::1", "hostname for a CNAME record (use an A or AAAA record for an IP)"],
     ] as const) {
       expect(
         desiredFromContainer(
@@ -108,6 +107,57 @@ describe("desiredFromContainer", () => {
         `[labels] /whoami: dockroute.target "${target}" is not a valid ${expected}, skipping`,
       );
     }
+  });
+
+  test("trims explicit targets before validation and storage", () => {
+    for (const [type, target, expectedTarget] of [
+      ["A", " 192.0.2.1 ", "192.0.2.1"],
+      ["AAAA", " 2001:db8::1 ", "2001:db8::1"],
+      ["CNAME", " origin.example.com ", "origin.example.com"],
+    ] as const) {
+      const { records } = desiredFromContainer(
+        container({
+          "dockroute.enabled": "true",
+          "dockroute.hostname": "app.example.com",
+          "dockroute.type": type,
+          "dockroute.target": target,
+        }),
+      );
+      expect(records[0]).toMatchObject({ type, target: expectedTarget });
+    }
+  });
+
+  test("treats a blank explicit target as missing", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    const withDefault = desiredFromContainer(
+      container({
+        "dockroute.enabled": "true",
+        "dockroute.hostname": "app.example.com",
+        "dockroute.type": "CNAME",
+        "dockroute.target": "   ",
+      }),
+      { defaultTarget: "origin.example.com" },
+    );
+    expect(withDefault.records[0]).toMatchObject({
+      type: "CNAME",
+      target: "origin.example.com",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    expect(
+      desiredFromContainer(
+        container({
+          "dockroute.enabled": "true",
+          "dockroute.hostname": "app.example.com",
+          "dockroute.type": "CNAME",
+          "dockroute.target": "   ",
+        }),
+      ),
+    ).toEqual(empty);
+    expect(warnSpy).toHaveBeenLastCalledWith(
+      "[labels] /whoami: no dockroute.target and no default target, skipping",
+    );
   });
 
   test("validates an inherited default target", () => {

--- a/src/core/labels.test.ts
+++ b/src/core/labels.test.ts
@@ -65,6 +65,68 @@ describe("desiredFromContainer", () => {
     expect(record).toMatchObject({ type: "CNAME", target: "origin.example.com", ttl: 60 });
   });
 
+  test("validates targets against their record type", () => {
+    for (const [type, target] of [
+      ["A", "192.0.2.1"],
+      ["AAAA", "2001:db8::1"],
+      ["CNAME", "origin.example.com"],
+    ] as const) {
+      const { records } = desiredFromContainer(
+        container({
+          "dockroute.enabled": "true",
+          "dockroute.hostname": "app.example.com",
+          "dockroute.type": type,
+          "dockroute.target": target,
+        }),
+      );
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({ type, target });
+    }
+  });
+
+  test("skips targets that do not match their record type", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    for (const [type, target, expected] of [
+      ["A", "2001:db8::1", "IPv4 address for an A record"],
+      ["AAAA", "192.0.2.1", "IPv6 address for an AAAA record"],
+      ["CNAME", "192.0.2.1", "hostname for a CNAME record"],
+      ["CNAME", "2001:db8::1", "hostname for a CNAME record"],
+      ["CNAME", "   ", "hostname for a CNAME record"],
+    ] as const) {
+      expect(
+        desiredFromContainer(
+          container({
+            "dockroute.enabled": "true",
+            "dockroute.hostname": "app.example.com",
+            "dockroute.type": type,
+            "dockroute.target": target,
+          }),
+        ),
+      ).toEqual(empty);
+      expect(warnSpy).toHaveBeenLastCalledWith(
+        `[labels] /whoami: dockroute.target "${target}" is not a valid ${expected}, skipping`,
+      );
+    }
+  });
+
+  test("validates an inherited default target", () => {
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    expect(
+      desiredFromContainer(
+        container({
+          "dockroute.enabled": "true",
+          "dockroute.hostname": "app.example.com",
+          "dockroute.type": "AAAA",
+        }),
+        { defaultTarget: "192.0.2.1" },
+      ),
+    ).toEqual(empty);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[labels] /whoami: dockroute.target "192.0.2.1" is not a valid IPv6 address for an AAAA record, skipping',
+    );
+  });
+
   test("warns and uses the default when an explicit ttl is invalid", () => {
     warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     const [record] = desiredFromContainer(
@@ -132,7 +194,7 @@ describe("desiredFromContainer", () => {
         "dockroute.enabled": "true",
         "dockroute.hostname": "a.example.com",
         "dockroute.tunnel.service": "https://whoami:443",
-        "dockroute.type": "A",
+        "dockroute.type": "AAAA",
         "dockroute.target": "10.0.0.1",
       }),
     );

--- a/src/core/labels.ts
+++ b/src/core/labels.ts
@@ -1,3 +1,4 @@
+import { isIP, isIPv4, isIPv6 } from "node:net";
 import type { ContainerInfo, DesiredState, DnsRecord, RecordType } from "./types";
 
 const PREFIX = "dockroute.";
@@ -93,6 +94,13 @@ function dnsState(
     console.warn(`[labels] ${name}: no dockroute.target and no default target, skipping`);
     return emptyDesiredState();
   }
+  const type = rawType as RecordType;
+  if (!isValidTarget(type, target)) {
+    console.warn(
+      `[labels] ${name}: dockroute.target "${target}" is not a valid ${targetRequirement(type)}, skipping`,
+    );
+    return emptyDesiredState();
+  }
 
   const rawTtl = labels[`${PREFIX}ttl`];
   const parsedTtl = Number(rawTtl ?? DEFAULT_TTL);
@@ -104,13 +112,35 @@ function dnsState(
 
   const records: DnsRecord[] = hostnames.map((hostname) => ({
     hostname,
-    type: rawType as RecordType,
+    type,
     target,
     ttl,
     source: container.Id,
     ...(providerSpecific ? { providerSpecific } : {}),
   }));
   return { records, tunnelRoutes: [] };
+}
+
+function isValidTarget(type: RecordType, target: string): boolean {
+  switch (type) {
+    case "A":
+      return isIPv4(target);
+    case "AAAA":
+      return isIPv6(target);
+    case "CNAME":
+      return target.trim().length > 0 && isIP(target.trim()) === 0;
+  }
+}
+
+function targetRequirement(type: RecordType): string {
+  switch (type) {
+    case "A":
+      return "IPv4 address for an A record";
+    case "AAAA":
+      return "IPv6 address for an AAAA record";
+    case "CNAME":
+      return "hostname for a CNAME record";
+  }
 }
 
 function isValidServiceUrl(service: string): boolean {

--- a/src/core/labels.ts
+++ b/src/core/labels.ts
@@ -89,7 +89,7 @@ function dnsState(
     return emptyDesiredState();
   }
 
-  const target = labels[`${PREFIX}target`] ?? opts.defaultTarget;
+  const target = labels[`${PREFIX}target`]?.trim() || opts.defaultTarget;
   if (!target) {
     console.warn(`[labels] ${name}: no dockroute.target and no default target, skipping`);
     return emptyDesiredState();
@@ -128,7 +128,7 @@ function isValidTarget(type: RecordType, target: string): boolean {
     case "AAAA":
       return isIPv6(target);
     case "CNAME":
-      return target.trim().length > 0 && isIP(target.trim()) === 0;
+      return isIP(target) === 0;
   }
 }
 
@@ -139,7 +139,7 @@ function targetRequirement(type: RecordType): string {
     case "AAAA":
       return "IPv6 address for an AAAA record";
     case "CNAME":
-      return "hostname for a CNAME record";
+      return "hostname for a CNAME record (use an A or AAAA record for an IP)";
   }
 }
 


### PR DESCRIPTION
Validate `dockroute.target` against A, AAAA, and CNAME record types before provider reconciliation, with coverage for invalid and inherited targets.

Closes #32

Tests: `bun test`, `bun run typecheck`, `bun run lint`
