### PR TITLE
chore: update Biome schema version

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
Updates the Biome schema reference to 2.5.8, matching the resolved version in bun.lock so lint no longer reports a version mismatch.

Tests: bun test, bun run typecheck, bun run lint.

Fixes #33