### PR TITLE
fix(ci): restore release note generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,21 @@ jobs:
     needs: verify
     permissions:
       contents: read
+    env:
+      # Single source of truth: the dry run that guards the notes and the real
+      # release must resolve the exact same plugin tree, or the guard proves
+      # nothing about what ships.
+      #
+      # Stay on the conventionalcommits 9.x line. The 10.x line requires
+      # conventional-changelog-writer@9, while semantic-release 25 resolves
+      # writer 8 via @semantic-release/release-notes-generator@14 (^8.0.0).
+      # On 10.2.x/10.3.x that mismatch renders empty release notes without an
+      # error, which is how v0.1.1 through v0.3.1 shipped with no body (#44).
+      # Move past 9.x only once release-notes-generator depends on writer@9.
+      RELEASE_PLUGINS: |
+        @semantic-release/changelog@7
+        @semantic-release/git@11
+        conventional-changelog-conventionalcommits@9.3.1
     outputs:
       published: ${{ steps.semantic.outputs.new_release_published }}
       version: ${{ steps.semantic.outputs.new_release_version }}
@@ -72,18 +87,39 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      # Empty release notes fail nothing on their own, so they went unnoticed for
+      # six releases. Generating them once in dry-run mode turns that into a red
+      # build before anything is tagged or published.
+      - name: Dry run to generate the release notes
+        id: dry_run
+        uses: cycjimmy/semantic-release-action@v6
+        with:
+          dry_run: true
+          extra_plugins: ${{ env.RELEASE_PLUGINS }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Fail on empty release notes
+        if: steps.dry_run.outputs.new_release_published == 'true'
+        env:
+          # Read through the environment, never interpolated into the script.
+          NOTES: ${{ steps.dry_run.outputs.new_release_notes }}
+        run: |
+          # Line 1 is the version header, which renders even when every commit
+          # section is missing. The body is what proves the writer ran.
+          if [ -z "$(printf '%s' "$NOTES" | tail -n +2 | tr -d '[:space:]')" ]; then
+            echo "::error::semantic-release generated release notes with no body. \
+          The conventionalcommits preset and conventional-changelog-writer are \
+          probably out of step again; see issue #44."
+            exit 1
+          fi
+          echo "Release notes carry a body."
+
       - name: Run semantic-release
         id: semantic
         uses: cycjimmy/semantic-release-action@v6
         with:
-          # Exact pins: the preset reaches @conventional-changelog/template through a
-          # caret range, and 1.4.0 requires conventional-changelog-writer@9, while
-          # semantic-release 25 still bundles writer 8. Unpin once it ships writer@9.
-          extra_plugins: |
-            @semantic-release/changelog@7
-            @semantic-release/git@11
-            conventional-changelog-conventionalcommits@10.3.0
-            @conventional-changelog/template@1.3.0
+          extra_plugins: ${{ env.RELEASE_PLUGINS }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Closes #44.

## Why

`conventional-changelog-conventionalcommits@10.x` requires `conventional-changelog-writer@9`. `semantic-release@25` resolves writer `8.4.0`, through `@semantic-release/release-notes-generator@14.1.1`, which declares `^8.0.0`. On preset 10.2.x and 10.3.x that mismatch renders an empty body and does not raise, so every release from v0.1.1 to v0.3.1 published nothing but a version header, and `CHANGELOG.md` is 11 lines of headers.

The old pin on `@conventional-changelog/template@1.3.0` was aimed at the wrong package. The template version makes no difference to the outcome; the preset major is what decides it.

## What changed

- Preset moves to `conventional-changelog-conventionalcommits@9.3.1`, which renders correctly against writer 8. The `@conventional-changelog/template` pin goes away with it.
- The stale comment is replaced with the actual constraint, and the condition for moving past 9.x: `release-notes-generator` depending on `writer@9`.
- A dry run generates the notes before the real release, and the job fails when the body is empty. This is the part that keeps the bug from coming back silently, since empty notes fail nothing on their own.
- Both the dry run and the real run read `extra_plugins` from one `RELEASE_PLUGINS` env var, so the guard cannot drift from the tree that actually ships.

## Verification

`release.yml` only runs on push to `main`, so this PR's CI does not exercise it. Verified locally against the real stack instead (`semantic-release@25.0.9`, writer `8.4.0`), in a throwaway clone with `feat`, `fix` and `feat!` commits stacked on `main`:

| preset | `--dry-run` output |
| --- | --- |
| `10.3.0` (before) | `## 1.0.0 (compare link) (date)` and nothing else |
| `9.3.1` (after) | `### ⚠ BREAKING CHANGES`, `### Features`, `### Bug Fixes`, with commit and issue links |

`10.2.1` behaves like `10.3.0`. `10.4.0` throws `Missing helper: ... requires conventional-changelog-writer@9 or newer` instead of rendering empty, so a future accidental bump fails loudly rather than silently.

The guard script was run verbatim out of the parsed YAML, against the notes body from each case: exit 1 on the header-only string, exit 0 once a section is present, and exit 0 skipped entirely when no release is due.

This is not a short-lived pin. `semantic-release@26.0.0-beta.1` still depends on `release-notes-generator@^14.1.0` and so still resolves writer 8. `release-notes-generator@15.0.0-beta.1` exists but nothing wires it in yet.

## Out of scope

The six existing `CHANGELOG.md` entries stay empty. Backfilling them from git history is a separate call.
